### PR TITLE
fix(org): allow full org management without requiring a workspace

### DIFF
--- a/changeslog.md
+++ b/changeslog.md
@@ -1,7 +1,229 @@
 # Production-Readiness Perfection Check - Complete Changelog
 
 > **Session Date:** December 25, 2025  
-> **Objective:** Frontend UX Polish and Build Cleanup
+> **Objective:** Organization Onboarding Flow (Session 4)
+
+---
+
+## 📋 Executive Summary (Session 4)
+
+Implemented **stepper-driven ORG onboarding flow** ensuring no half-initialized organizations:
+
+1. ✅ **Stepper Component** - Visual progress indicator for 5-step flow
+2. ✅ **Organization Setup Page** - Create org after email verification (ORG only)
+3. ✅ **Workspace Setup Page** - Optional workspace creation or skip
+4. ✅ **Prefs Update Endpoint** - Track onboarding state
+5. ✅ **Verification Redirect** - ORG users redirected to org setup
+6. ✅ **Dashboard Guard** - Block app entry until onboarding complete
+
+**Result:** ✅ Build passes with zero warnings
+
+---
+
+## 📊 Stepper Flow
+
+```
+PERSONAL: Step 1 (Signup) → Step 2 (Verify) → App
+ORG:      Step 1 → Step 2 → Step 3 (Org Setup) → Step 4 (Workspace) → App
+```
+
+---
+
+## 🆕 New Files Created
+
+| File | Purpose |
+|------|---------|
+| `src/components/onboarding-stepper.tsx` | Visual stepper UI |
+| `src/app/(auth)/onboarding/organization/page.tsx` | Org setup form |
+| `src/app/(auth)/onboarding/workspace/page.tsx` | Optional workspace setup |
+| `src/features/onboarding/hooks/use-onboarding-state.ts` | State tracking |
+
+---
+
+## 🔧 Files Modified
+
+| File | Change |
+|------|--------|
+| `src/features/auth/server/route.ts` | Added `/update-prefs` endpoint, verify-email returns accountType |
+| `src/features/auth/api/use-verify-email.ts` | Redirects ORG users to org setup |
+| `src/components/app-readiness-provider.tsx` | Added onboarding guard |
+
+---
+
+## 🛡️ Routing Guards
+
+```
+IF !authenticated → /sign-in
+IF !emailVerified → /verify-email-needed
+IF accountType === ORG AND !orgSetupComplete → /onboarding/organization
+ELSE → App
+```
+
+---
+
+---
+
+> **Session Date:** December 25, 2025  
+> **Objective:** Organization Settings - Full Functionality (Session 3)
+
+---
+
+## 📋 Executive Summary (Session 3)
+
+Made **Organization Settings fully functional** with real backend data across all 5 sections:
+
+1. ✅ **General Settings** - Real org data, edit/save with change detection
+2. ✅ **Members Management** - List, role changes, removal with confirmation  
+3. ✅ **Billing Settings** - Already functional
+4. ✅ **Danger Zone** - OWNER-only delete with type-to-confirm
+5. ✅ **Audit Logs** - Already functional
+
+**Result:** ✅ Build passes with zero warnings
+
+---
+
+## 🆕 New API Hooks Created
+
+| Hook | Purpose |
+|------|---------|
+| `useUpdateOrganization` | Update org name/logo |
+| `useGetOrgMembers` | Fetch all org members |
+| `useAddOrgMember` | Add member to org |
+| `useUpdateOrgMemberRole` | Change member role |
+| `useRemoveOrgMember` | Remove member |
+| `useDeleteOrganization` | Soft-delete org (OWNER only) |
+| `useCurrentOrgMember` | Get current user's role in org |
+
+---
+
+## 🔧 Organization Settings Sections
+
+### 1️⃣ General Settings
+- Fetches real org data on load
+- Editable name field (ADMIN+ only)
+- Read-only org ID and creation date
+- Change detection (save disabled if no changes)
+- Loading states and success feedback
+
+### 2️⃣ Members Management
+- Real members list from backend
+- Role selector per member (ADMIN+ can change)
+- Remove member with confirmation dialog
+- Protection: Cannot remove last OWNER
+- Inline loading states
+
+### 3️⃣ Billing Settings
+- Already implemented (previous session)
+
+### 4️⃣ Danger Zone (OWNER Only)
+- Type organization name to confirm deletion
+- Soft-delete with 30-day retention
+- Redirect to home after deletion
+
+### 5️⃣ Audit Logs (OWNER Only)
+- Already implemented (previous session)
+
+---
+
+## 🔐 Permission Model
+
+| Role | General | Members | Danger Zone | Audit |
+|------|---------|---------|-------------|-------|
+| OWNER | Edit | Edit + Remove | Delete | View |
+| ADMIN | Edit | Edit + Remove | Hidden | Hidden |
+| MEMBER | View | View | Hidden | Hidden |
+
+---
+
+---
+
+> **Session Date:** December 25, 2025  
+> **Objective:** Production Polish & Hardening (Session 2)
+
+---
+
+## 📋 Executive Summary (Session 2)
+
+This session implemented **5 production polish improvements** for operational readiness:
+
+1. ✅ **Safe Global Refresh Throttling** - 2s cooldown, batched queries, deferred heavy queries
+2. ✅ **Global Loader Timeout Copy** - Clearer message for first login/slow connections
+3. ✅ **Organization Audit Log View** - OWNER-only read-only compliance view
+4. ✅ **Refresh Edge-Case Guards** - Access loss detection with graceful redirects
+5. ✅ **Developer Comments** - Inline documentation for critical billing/conversion logic
+
+**Result:** ✅ Build passes with zero errors
+
+---
+
+## 🔄 Improvement 1: Safe Global Refresh Throttling
+
+**File:** [`src/hooks/use-app-refresh.ts`](file:///Users/surendram.dev/Documents/CODE/Fairlx/Fairlx-main/src/hooks/use-app-refresh.ts)
+
+**Changes:**
+- Added 2-second throttle window to prevent rapid refreshes
+- **Batch 1 (Immediate):** core queries (auth, workspace, organizations, members)
+- **Batch 2 (Deferred 500ms):** heavy queries (billing, analytics, audit-logs)
+- Prevents multiple concurrent refreshes
+
+---
+
+## 💬 Improvement 2: Global Loader Timeout Copy
+
+**File:** [`src/components/global-app-loader.tsx`](file:///Users/surendram.dev/Documents/CODE/Fairlx/Fairlx-main/src/components/global-app-loader.tsx)
+
+**Before:** "This is taking longer than expected"  
+**After:** "This may take a bit longer on first login or slow connections"
+
+---
+
+## 📋 Improvement 3: Organization Audit Log View
+
+**New Files:**
+- [`src/features/organizations/api/use-get-org-audit-logs.ts`](file:///Users/surendram.dev/Documents/CODE/Fairlx/Fairlx-main/src/features/organizations/api/use-get-org-audit-logs.ts)
+- [`src/features/organizations/components/organization-audit-logs.tsx`](file:///Users/surendram.dev/Documents/CODE/Fairlx/Fairlx-main/src/features/organizations/components/organization-audit-logs.tsx)
+
+**Modified:**
+- [`src/features/organizations/server/route.ts`](file:///Users/surendram.dev/Documents/CODE/Fairlx/Fairlx-main/src/features/organizations/server/route.ts) - Added `GET /:orgId/audit-logs`
+- [`src/app/(dashboard)/workspaces/[workspaceId]/organization/client.tsx`](file:///Users/surendram.dev/Documents/CODE/Fairlx/Fairlx-main/src/app/(dashboard)/workspaces/[workspaceId]/organization/client.tsx) - Added Audit tab
+
+**Features:**
+- OWNER-only access (enforced server-side)
+- Displays: timestamp, actor ID, action type, metadata
+- Pagination (20 per page)
+- Filter by action type
+
+---
+
+## 🛡️ Improvement 4: Refresh Edge-Case Guards
+
+**File:** [`src/hooks/use-app-refresh.ts`](file:///Users/surendram.dev/Documents/CODE/Fairlx/Fairlx-main/src/hooks/use-app-refresh.ts)
+
+**Guards Added:**
+- Prevents refresh while already refreshing
+- Detects 401 (Session expired) → redirect to /sign-in with toast
+- Detects 403 (Access changed) → redirect to / with "Your access has changed" toast
+- Prevents raw error screens for expected permission changes
+
+---
+
+## 📝 Improvement 5: Developer Comments
+
+**Files with Enhanced Documentation:**
+
+| File | Documentation Added |
+|------|---------------------|
+| `use-app-refresh.ts` | Why refresh doesn't reload the page |
+| `traffic-metering-middleware.ts` | Why metadata stores billingEntity (temporary) |
+| `organizations/types.ts` | Why billingStartAt determines billing attribution |
+| `organizations/server/route.ts` | Why conversion is one-way and atomic |
+
+---
+
+---
+
+> **Session Date:** December 25, 2025  
+> **Objective:** Frontend UX Polish and Build Cleanup (Session 1)
 
 ---
 

--- a/scripts/add-org-id-to-workspaces.js
+++ b/scripts/add-org-id-to-workspaces.js
@@ -1,0 +1,35 @@
+const { Client, Databases } = require('node-appwrite');
+require('dotenv').config({ path: '.env.local' });
+
+const client = new Client()
+    .setEndpoint(process.env.NEXT_PUBLIC_APPWRITE_ENDPOINT)
+    .setProject(process.env.NEXT_PUBLIC_APPWRITE_PROJECT)
+    .setKey(process.env.NEXT_APPWRITE_KEY);
+
+const databases = new Databases(client);
+
+const DATABASE_ID = process.env.NEXT_PUBLIC_APPWRITE_DATABASE_ID;
+const WORKSPACES_ID = process.env.NEXT_PUBLIC_APPWRITE_WORKSPACES_ID;
+
+async function migrate() {
+    if (!DATABASE_ID || !WORKSPACES_ID) {
+        console.error('Missing DATABASE_ID or WORKSPACES_ID in environment variables.');
+        process.exit(1);
+    }
+
+    try {
+        console.log(`Adding organizationId attribute to workspaces collection [${WORKSPACES_ID}] in database [${DATABASE_ID}]...`);
+        await databases.createStringAttribute(
+            DATABASE_ID,
+            WORKSPACES_ID,
+            'organizationId',
+            50,
+            false // required = false
+        );
+        console.log('Attribute added successfully.');
+    } catch (error) {
+        console.error('Error adding attribute:', error);
+    }
+}
+
+migrate();

--- a/scripts/fix-workspace-schema.js
+++ b/scripts/fix-workspace-schema.js
@@ -1,0 +1,58 @@
+const { Client, Databases } = require('node-appwrite');
+require('dotenv').config({ path: '.env.local' });
+
+const client = new Client()
+    .setEndpoint(process.env.NEXT_PUBLIC_APPWRITE_ENDPOINT)
+    .setProject(process.env.NEXT_PUBLIC_APPWRITE_PROJECT)
+    .setKey(process.env.NEXT_APPWRITE_KEY);
+
+const databases = new Databases(client);
+
+const DATABASE_ID = process.env.NEXT_PUBLIC_APPWRITE_DATABASE_ID;
+const WORKSPACES_ID = process.env.NEXT_PUBLIC_APPWRITE_WORKSPACES_ID;
+
+async function migrate() {
+    if (!DATABASE_ID || !WORKSPACES_ID) {
+        console.error('Missing DATABASE_ID or WORKSPACES_ID in environment variables.');
+        process.exit(1);
+    }
+
+    try {
+        console.log(`Checking and adding attributes to workspaces collection [${WORKSPACES_ID}]...`);
+
+        // Add billingScope
+        try {
+            console.log('Adding billingScope attribute...');
+            await databases.createStringAttribute(
+                DATABASE_ID,
+                WORKSPACES_ID,
+                'billingScope',
+                50,
+                false // required = false
+            );
+            console.log('billingScope added.');
+        } catch (error) {
+            console.log('billingScope might already exist or failed:', error.message);
+        }
+
+        // Add isDefault
+        try {
+            console.log('Adding isDefault attribute...');
+            await databases.createBooleanAttribute(
+                DATABASE_ID,
+                WORKSPACES_ID,
+                'isDefault',
+                false // required = false
+            );
+            console.log('isDefault added.');
+        } catch (error) {
+            console.log('isDefault might already exist or failed:', error.message);
+        }
+
+        console.log('Migration attempts finished.');
+    } catch (error) {
+        console.error('Migration failed:', error);
+    }
+}
+
+migrate();

--- a/src/app/(auth)/onboarding/organization/page.tsx
+++ b/src/app/(auth)/onboarding/organization/page.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Building2, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { OnboardingStepper, OnboardingStep } from "@/components/onboarding-stepper";
+import { useCurrent } from "@/features/auth/api/use-current";
+
+const organizationSetupSchema = z.object({
+    name: z.string().min(2, "Organization name must be at least 2 characters"),
+    size: z.string().optional(),
+});
+
+type OrganizationSetupForm = z.infer<typeof organizationSetupSchema>;
+
+const ORGANIZATION_SIZES = [
+    { value: "1-10", label: "1-10 employees" },
+    { value: "11-50", label: "11-50 employees" },
+    { value: "51-200", label: "51-200 employees" },
+    { value: "201-500", label: "201-500 employees" },
+    { value: "500+", label: "500+ employees" },
+];
+
+export default function OrganizationSetupPage() {
+    const router = useRouter();
+    const { data: user, isLoading: isUserLoading } = useCurrent();
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [isRedirecting, setIsRedirecting] = useState(false);
+
+    const prefs = user?.prefs || {};
+    const pendingOrgName = prefs.pendingOrganizationName as string || "";
+
+    const form = useForm<OrganizationSetupForm>({
+        resolver: zodResolver(organizationSetupSchema),
+        defaultValues: {
+            name: pendingOrgName,
+            size: "",
+        },
+    });
+
+    // Handle redirects in useEffect to avoid React render warnings
+    useEffect(() => {
+        if (isUserLoading) return;
+
+        // Redirect if not ORG account
+        if (prefs.accountType !== "ORG") {
+            setIsRedirecting(true);
+            router.push("/");
+            return;
+        }
+
+        // Redirect if already setup
+        if (prefs.orgSetupComplete) {
+            setIsRedirecting(true);
+            router.push("/onboarding/workspace");
+            return;
+        }
+    }, [isUserLoading, prefs.accountType, prefs.orgSetupComplete, router]);
+
+    const onSubmit = async (values: OrganizationSetupForm) => {
+        setIsSubmitting(true);
+
+        try {
+            // Create organization via API
+            const formData = new FormData();
+            formData.append("name", values.name);
+
+            const response = await fetch("/api/organizations", {
+                method: "POST",
+                body: formData,
+                credentials: "include",
+            });
+
+            if (!response.ok) {
+                const error = await response.json().catch(() => ({}));
+                throw new Error(error.error || "Failed to create organization");
+            }
+
+            const { data: organization } = await response.json();
+
+            // Update user prefs to mark org setup complete
+            const prefsResponse = await fetch("/api/auth/update-prefs", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    orgSetupComplete: true,
+                    primaryOrganizationId: organization.$id,
+                    organizationSize: values.size || null,
+                    onboardingStep: "ORG_SETUP_COMPLETED",
+                }),
+                credentials: "include",
+            });
+
+            if (!prefsResponse.ok) {
+                console.error("Failed to update prefs, but org was created");
+            }
+
+            toast.success("Organization created!", {
+                description: "Your organization is ready.",
+            });
+
+            // Redirect to workspace setup
+            router.push("/onboarding/workspace");
+        } catch (error) {
+            console.error("Organization setup error:", error);
+            toast.error(error instanceof Error ? error.message : "Failed to create organization");
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    // Show loading state
+    if (isUserLoading || isRedirecting) {
+        return (
+            <div className="flex items-center justify-center min-h-screen">
+                <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex flex-col items-center justify-center min-h-screen p-6 bg-muted/30">
+            {/* Stepper */}
+            <div className="mb-8">
+                <OnboardingStepper
+                    currentStep={OnboardingStep.ORG_SETUP}
+                    accountType="ORG"
+                />
+            </div>
+
+            {/* Setup Card */}
+            <Card className="w-full max-w-lg">
+                <CardHeader className="text-center">
+                    <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-primary/10">
+                        <Building2 className="h-7 w-7 text-primary" />
+                    </div>
+                    <CardTitle className="text-2xl">Set Up Your Organization</CardTitle>
+                    <CardDescription>
+                        Create your organization to start collaborating with your team.
+                    </CardDescription>
+                </CardHeader>
+                <CardContent>
+                    <Form {...form}>
+                        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+                            <FormField
+                                control={form.control}
+                                name="name"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel>Organization Name *</FormLabel>
+                                        <FormControl>
+                                            <Input
+                                                {...field}
+                                                placeholder="Acme Corporation"
+                                                disabled={isSubmitting}
+                                            />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+
+                            <FormField
+                                control={form.control}
+                                name="size"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel>Organization Size (optional)</FormLabel>
+                                        <Select
+                                            onValueChange={field.onChange}
+                                            defaultValue={field.value}
+                                            disabled={isSubmitting}
+                                        >
+                                            <FormControl>
+                                                <SelectTrigger>
+                                                    <SelectValue placeholder="Select size" />
+                                                </SelectTrigger>
+                                            </FormControl>
+                                            <SelectContent>
+                                                {ORGANIZATION_SIZES.map((size) => (
+                                                    <SelectItem key={size.value} value={size.value}>
+                                                        {size.label}
+                                                    </SelectItem>
+                                                ))}
+                                            </SelectContent>
+                                        </Select>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+
+                            <Button
+                                type="submit"
+                                className="w-full"
+                                size="lg"
+                                disabled={isSubmitting}
+                            >
+                                {isSubmitting ? (
+                                    <>
+                                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                        Creating Organization...
+                                    </>
+                                ) : (
+                                    "Create Organization"
+                                )}
+                            </Button>
+                        </form>
+                    </Form>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/src/app/(auth)/onboarding/workspace/page.tsx
+++ b/src/app/(auth)/onboarding/workspace/page.tsx
@@ -1,0 +1,256 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Folder, Loader2, ArrowRight, SkipForward } from "lucide-react";
+import { toast } from "sonner";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { OnboardingStepper, OnboardingStep } from "@/components/onboarding-stepper";
+import { useCurrent } from "@/features/auth/api/use-current";
+
+const workspaceSetupSchema = z.object({
+    name: z.string().min(2, "Workspace name must be at least 2 characters"),
+});
+
+type WorkspaceSetupForm = z.infer<typeof workspaceSetupSchema>;
+
+export default function WorkspaceSetupPage() {
+    const router = useRouter();
+    const { data: user, isLoading: isUserLoading } = useCurrent();
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [isSkipping, setIsSkipping] = useState(false);
+    const [showCreateForm, setShowCreateForm] = useState(false);
+    const [isRedirecting, setIsRedirecting] = useState(false);
+
+    const prefs = user?.prefs || {};
+
+    const form = useForm<WorkspaceSetupForm>({
+        resolver: zodResolver(workspaceSetupSchema),
+        defaultValues: {
+            name: "",
+        },
+    });
+
+    // Handle redirects in useEffect to avoid React render warnings
+    useEffect(() => {
+        if (isUserLoading) return;
+
+        // Redirect if personal account
+        if (prefs.accountType !== "ORG") {
+            setIsRedirecting(true);
+            router.push("/");
+            return;
+        }
+
+        // Redirect if org not setup
+        if (!prefs.orgSetupComplete) {
+            setIsRedirecting(true);
+            router.push("/onboarding/organization");
+            return;
+        }
+    }, [isUserLoading, prefs.accountType, prefs.orgSetupComplete, router]);
+
+    const handleSkip = async () => {
+        setIsSkipping(true);
+
+        try {
+            // Update prefs to mark onboarding complete with workspace skipped
+            // IMPORTANT: No workspace is created - user enters ZERO-WORKSPACE state
+            const response = await fetch("/api/auth/update-prefs", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    onboardingStep: "WORKSPACE_SKIPPED",
+                    workspaceSkipped: true,
+                }),
+                credentials: "include",
+            });
+
+            if (!response.ok) {
+                throw new Error("Failed to complete setup");
+            }
+
+            toast.success("Setup complete!", {
+                description: "You can create workspaces anytime from the dashboard.",
+            });
+
+            // Redirect directly to welcome page (zero-workspace home)
+            router.push("/welcome");
+        } catch (error) {
+            console.error("Skip error:", error);
+            toast.error("Failed to complete setup");
+        } finally {
+            setIsSkipping(false);
+        }
+    };
+
+    const onSubmit = async (values: WorkspaceSetupForm) => {
+        setIsSubmitting(true);
+
+        try {
+            // Create workspace via API
+            const formData = new FormData();
+            formData.append("name", values.name);
+
+            const response = await fetch("/api/workspaces", {
+                method: "POST",
+                body: formData,
+                credentials: "include",
+            });
+
+            if (!response.ok) {
+                const error = await response.json().catch(() => ({}));
+                throw new Error(error.error || "Failed to create workspace");
+            }
+
+            // Update prefs to mark onboarding complete
+            await fetch("/api/auth/update-prefs", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    onboardingStep: "COMPLETED",
+                }),
+                credentials: "include",
+            });
+
+            toast.success("Workspace created!", {
+                description: "Your setup is complete.",
+            });
+
+            router.push("/");
+        } catch (error) {
+            console.error("Workspace setup error:", error);
+            toast.error(error instanceof Error ? error.message : "Failed to create workspace");
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    // Show loading state
+    if (isUserLoading || isRedirecting) {
+        return (
+            <div className="flex items-center justify-center min-h-screen">
+                <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex flex-col items-center justify-center min-h-screen p-6 bg-muted/30">
+            {/* Stepper */}
+            <div className="mb-8">
+                <OnboardingStepper
+                    currentStep={OnboardingStep.WORKSPACE_SETUP}
+                    accountType="ORG"
+                />
+            </div>
+
+            {/* Setup Card */}
+            <Card className="w-full max-w-lg">
+                <CardHeader className="text-center">
+                    <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-green-100">
+                        <Folder className="h-7 w-7 text-green-600" />
+                    </div>
+                    <CardTitle className="text-2xl">Your Organization is Ready! 🎉</CardTitle>
+                    <CardDescription>
+                        Would you like to create your first workspace now?
+                    </CardDescription>
+                </CardHeader>
+                <CardContent>
+                    {!showCreateForm ? (
+                        <div className="space-y-4">
+                            <Button
+                                className="w-full"
+                                size="lg"
+                                onClick={() => setShowCreateForm(true)}
+                            >
+                                <Folder className="mr-2 h-4 w-4" />
+                                Create Workspace
+                            </Button>
+                            <Button
+                                variant="outline"
+                                className="w-full"
+                                size="lg"
+                                onClick={handleSkip}
+                                disabled={isSkipping}
+                            >
+                                {isSkipping ? (
+                                    <>
+                                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                        Completing...
+                                    </>
+                                ) : (
+                                    <>
+                                        <SkipForward className="mr-2 h-4 w-4" />
+                                        Skip for Now
+                                    </>
+                                )}
+                            </Button>
+                            <p className="text-xs text-muted-foreground text-center">
+                                You can create workspaces anytime from the dashboard.
+                            </p>
+                        </div>
+                    ) : (
+                        <Form {...form}>
+                            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+                                <FormField
+                                    control={form.control}
+                                    name="name"
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <FormLabel>Workspace Name</FormLabel>
+                                            <FormControl>
+                                                <Input
+                                                    {...field}
+                                                    placeholder="Engineering, Marketing, etc."
+                                                    disabled={isSubmitting}
+                                                />
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+
+                                <div className="flex gap-3">
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        className="flex-1"
+                                        onClick={() => setShowCreateForm(false)}
+                                        disabled={isSubmitting}
+                                    >
+                                        Back
+                                    </Button>
+                                    <Button
+                                        type="submit"
+                                        className="flex-1"
+                                        disabled={isSubmitting}
+                                    >
+                                        {isSubmitting ? (
+                                            <>
+                                                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                                Creating...
+                                            </>
+                                        ) : (
+                                            <>
+                                                Create
+                                                <ArrowRight className="ml-2 h-4 w-4" />
+                                            </>
+                                        )}
+                                    </Button>
+                                </div>
+                            </form>
+                        </Form>
+                    )}
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/src/app/(auth)/verify-email/page.tsx
+++ b/src/app/(auth)/verify-email/page.tsx
@@ -17,7 +17,7 @@ const VerifyEmailContent = () => {
   useEffect(() => {
     // Prevent multiple attempts
     if (hasAttempted.current) return;
-    
+
     const userId = searchParams.get("userId");
     const secret = searchParams.get("secret");
 
@@ -27,7 +27,7 @@ const VerifyEmailContent = () => {
     }
 
     hasAttempted.current = true;
-    
+
     verifyEmail.mutate(
       { json: { userId, secret } },
       {
@@ -66,18 +66,6 @@ const VerifyEmailContent = () => {
   }
 
   if (status === "success") {
-    // Check for stored returnUrl
-    const returnUrl = typeof window !== 'undefined' 
-      ? sessionStorage.getItem('postVerificationReturnUrl') 
-      : null;
-    
-    // Clear the stored URL
-    if (returnUrl && typeof window !== 'undefined') {
-      sessionStorage.removeItem('postVerificationReturnUrl');
-    }
-
-    const signInUrl = returnUrl ? `/sign-in?returnUrl=${encodeURIComponent(returnUrl)}` : '/sign-in';
-
     return (
       <div className="flex items-center justify-center min-h-screen">
         <Card className="w-full max-w-md">
@@ -87,15 +75,11 @@ const VerifyEmailContent = () => {
               Email Verified!
             </CardTitle>
             <CardDescription>
-              Your email has been successfully verified. You can now log in to your account.
+              Your email has been verified. Taking you to your dashboard...
             </CardDescription>
           </CardHeader>
-          <CardContent>
-            <Button asChild className="w-full">
-              <Link href={signInUrl}>
-                Continue to Login
-              </Link>
-            </Button>
+          <CardContent className="flex items-center justify-center py-4">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
           </CardContent>
         </Card>
       </div>

--- a/src/app/(dashboard)/organization/page.tsx
+++ b/src/app/(dashboard)/organization/page.tsx
@@ -1,0 +1,29 @@
+import { redirect } from "next/navigation";
+import { getCurrent } from "@/features/auth/queries";
+import { OrganizationSettingsClient } from "@/app/(dashboard)/workspaces/[workspaceId]/organization/client";
+
+/**
+ * Dashboard-level Organization Settings Page
+ * 
+ * This route is accessible at /organization (not workspace-scoped)
+ * Allows ORG account owners/admins to manage organization settings
+ * even when ZERO workspaces exist.
+ * 
+ * Organization is the control plane - it should never depend on workspace existence.
+ */
+export default async function OrganizationPage() {
+    const user = await getCurrent();
+
+    if (!user) {
+        redirect("/sign-in");
+    }
+
+    // Check if this is an ORG account
+    const prefs = user.prefs || {};
+    if (prefs.accountType !== "ORG") {
+        // PERSONAL accounts don't have organization settings
+        redirect("/");
+    }
+
+    return <OrganizationSettingsClient />;
+}

--- a/src/app/(dashboard)/welcome/page.tsx
+++ b/src/app/(dashboard)/welcome/page.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { CheckCircle, Circle, Building2, FolderPlus, Settings } from "lucide-react";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { useCurrent } from "@/features/auth/api/use-current";
+import { useAccountType } from "@/features/organizations/hooks/use-account-type";
+import { useCreateWorkspaceModal } from "@/features/workspaces/hooks/use-create-workspace-modal";
+
+interface ProgressStep {
+    label: string;
+    complete: boolean;
+}
+
+const ProgressBar = ({ steps }: { steps: ProgressStep[] }) => {
+    const completedCount = steps.filter(s => s.complete).length;
+    const percentage = Math.round((completedCount / steps.length) * 100);
+
+    return (
+        <div className="space-y-4">
+            <div className="flex justify-between text-sm text-muted-foreground">
+                <span>Account Setup Progress</span>
+                <span>{percentage}% complete</span>
+            </div>
+            <div className="h-2 bg-muted rounded-full overflow-hidden">
+                <div
+                    className="h-full bg-primary transition-all duration-500"
+                    style={{ width: `${percentage}%` }}
+                />
+            </div>
+            <div className="flex flex-wrap gap-4">
+                {steps.map((step, index) => (
+                    <div key={index} className="flex items-center gap-2 text-sm">
+                        {step.complete ? (
+                            <CheckCircle className="h-4 w-4 text-green-600" />
+                        ) : (
+                            <Circle className="h-4 w-4 text-muted-foreground" />
+                        )}
+                        <span className={step.complete ? "text-foreground" : "text-muted-foreground"}>
+                            {step.label}
+                        </span>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+};
+
+export default function WelcomePage() {
+    const router = useRouter();
+    const { data: user } = useCurrent();
+    const { isOrg } = useAccountType();
+    const { open: openCreateWorkspace } = useCreateWorkspaceModal();
+
+    const prefs = user?.prefs || {};
+    const orgSetupComplete = prefs.orgSetupComplete === true;
+
+    // Build progress steps based on account type
+    const progressSteps: ProgressStep[] = [
+        { label: "Account created", complete: true },
+        { label: "Email verified", complete: user?.emailVerification === true },
+        ...(isOrg ? [{ label: "Organization setup", complete: orgSetupComplete }] : []),
+        { label: "Workspace created", complete: false }, // We're on this page because no workspace
+    ];
+
+    // Organization settings requires a workspace to exist first
+    // In zero-workspace state, we show a disabled button with explanation
+
+    return (
+        <div className="flex flex-col items-center justify-center min-h-[calc(100vh-80px)] p-6">
+            <div className="w-full max-w-2xl space-y-8">
+                {/* Welcome Header */}
+                <div className="text-center space-y-2">
+                    <h1 className="text-3xl font-bold">
+                        Welcome{user?.name ? `, ${user.name.split(" ")[0]}` : ""}! 🎉
+                    </h1>
+                    <p className="text-muted-foreground text-lg">
+                        Your account is ready. Let&apos;s set up your first workspace.
+                    </p>
+                </div>
+
+                {/* Progress Bar */}
+                <Card>
+                    <CardContent className="pt-6">
+                        <ProgressBar steps={progressSteps} />
+                    </CardContent>
+                </Card>
+
+                {/* Action Cards */}
+                <div className="grid gap-4 md:grid-cols-2">
+                    {/* Create Workspace - Primary CTA */}
+                    <Card className="border-2 border-primary/20 hover:border-primary/40 transition-colors cursor-pointer" onClick={openCreateWorkspace}>
+                        <CardHeader>
+                            <div className="flex items-center gap-3">
+                                <div className="p-2 rounded-lg bg-primary/10">
+                                    <FolderPlus className="h-6 w-6 text-primary" />
+                                </div>
+                                <div>
+                                    <CardTitle className="text-lg">Create Workspace</CardTitle>
+                                    <CardDescription>
+                                        Start collaborating with your team
+                                    </CardDescription>
+                                </div>
+                            </div>
+                        </CardHeader>
+                        <CardContent>
+                            <Button className="w-full" size="lg">
+                                Create Your First Workspace
+                            </Button>
+                        </CardContent>
+                    </Card>
+
+                    {/* Conditional: Manage Organization (ORG) or Manage Account (PERSONAL) */}
+                    {isOrg ? (
+                        <Card
+                            className="hover:border-muted-foreground/30 transition-colors cursor-pointer"
+                            onClick={() => router.push("/organization")}
+                        >
+                            <CardHeader>
+                                <div className="flex items-center gap-3">
+                                    <div className="p-2 rounded-lg bg-muted">
+                                        <Building2 className="h-6 w-6 text-muted-foreground" />
+                                    </div>
+                                    <div>
+                                        <CardTitle className="text-lg">Manage Organization</CardTitle>
+                                        <CardDescription>
+                                            View billing, members, and settings
+                                        </CardDescription>
+                                    </div>
+                                </div>
+                            </CardHeader>
+                            <CardContent>
+                                <Button
+                                    variant="outline"
+                                    className="w-full"
+                                    size="lg"
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        router.push("/organization");
+                                    }}
+                                >
+                                    Organization Settings
+                                </Button>
+                            </CardContent>
+                        </Card>
+                    ) : (
+                        <Card className="hover:border-muted-foreground/30 transition-colors">
+                            <CardHeader>
+                                <div className="flex items-center gap-3">
+                                    <div className="p-2 rounded-lg bg-muted">
+                                        <Settings className="h-6 w-6 text-muted-foreground" />
+                                    </div>
+                                    <div>
+                                        <CardTitle className="text-lg">Manage Account</CardTitle>
+                                        <CardDescription>
+                                            Update your profile and preferences
+                                        </CardDescription>
+                                    </div>
+                                </div>
+                            </CardHeader>
+                            <CardContent>
+                                <Button
+                                    variant="outline"
+                                    className="w-full"
+                                    size="lg"
+                                    onClick={() => router.push("/profile")}
+                                >
+                                    Account Settings
+                                </Button>
+                            </CardContent>
+                        </Card>
+                    )}
+                </div>
+
+                {/* Help Text */}
+                <p className="text-center text-sm text-muted-foreground">
+                    A workspace is where you organize your projects, tasks, and team collaboration.
+                    You can create multiple workspaces later.
+                </p>
+            </div>
+        </div>
+    );
+}

--- a/src/app/(dashboard)/workspaces/[workspaceId]/organization/client.tsx
+++ b/src/app/(dashboard)/workspaces/[workspaceId]/organization/client.tsx
@@ -1,7 +1,11 @@
 "use client";
 
-import { useState } from "react";
-import { Building2, Users, Settings2, Shield, Trash2, UserPlus, Crown, CreditCard, AlertTriangle } from "lucide-react";
+import { useState, useEffect } from "react";
+import { format } from "date-fns";
+import {
+    Building2, Users, Settings2, Shield, Trash2, Crown,
+    CreditCard, AlertTriangle, FileText, Loader2
+} from "lucide-react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -10,6 +14,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
     Select,
     SelectContent,
@@ -25,30 +30,118 @@ import {
     DialogHeader,
     DialogTitle,
     DialogTrigger,
+    DialogClose,
 } from "@/components/ui/dialog";
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+    AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+
 import { useAccountType } from "@/features/organizations/hooks/use-account-type";
-import { useGetOrganizations } from "@/features/organizations/api/use-get-organizations";
+import { useGetOrganization } from "@/features/organizations/api/use-get-organization";
+import { useUpdateOrganization } from "@/features/organizations/api/use-update-organization";
+import { useGetOrgMembers, OrgMember } from "@/features/organizations/api/use-get-org-members";
+import { useUpdateOrgMemberRole } from "@/features/organizations/api/use-update-org-member-role";
+import { useRemoveOrgMember } from "@/features/organizations/api/use-remove-org-member";
+import { useDeleteOrganization } from "@/features/organizations/api/use-delete-organization";
+import { useCurrentOrgMember } from "@/features/organizations/api/use-current-org-member";
 import { OrganizationRole } from "@/features/organizations/types";
 import { OrganizationBillingSettings } from "@/features/organizations/components/organization-billing-settings";
+import { OrganizationAuditLogs } from "@/features/organizations/components/organization-audit-logs";
 
 export const OrganizationSettingsClient = () => {
     const { isOrg, primaryOrganizationId } = useAccountType();
-    const { data: organizations } = useGetOrganizations();
-    const [inviteEmail, setInviteEmail] = useState("");
-    const [inviteRole, setInviteRole] = useState(OrganizationRole.MEMBER);
     const [activeTab, setActiveTab] = useState("general");
 
-    // Get current org
-    const currentOrg = isOrg && primaryOrganizationId
-        ? organizations?.documents?.find((o: { $id: string }) => o.$id === primaryOrganizationId)
-        : null;
+    // Fetch organization data
+    const {
+        data: organization,
+        isLoading: isLoadingOrg
+    } = useGetOrganization({ orgId: primaryOrganizationId || "" });
 
-    // Mock members data - in real implementation, fetch from API
-    const members = [
-        { id: "1", name: "John Doe", email: "john@example.com", role: "OWNER", avatar: null },
-        { id: "2", name: "Jane Smith", email: "jane@example.com", role: "ADMIN", avatar: null },
-        { id: "3", name: "Bob Wilson", email: "bob@example.com", role: "MEMBER", avatar: null },
-    ];
+    // Fetch members
+    const {
+        data: membersData,
+        isLoading: isLoadingMembers
+    } = useGetOrgMembers({ organizationId: primaryOrganizationId || "" });
+
+    // Current user's role
+    const { canEdit, isOwner, isLoading: isLoadingRole } = useCurrentOrgMember({
+        organizationId: primaryOrganizationId || ""
+    });
+
+    // General settings form state
+    const [orgName, setOrgName] = useState("");
+    const [hasChanges, setHasChanges] = useState(false);
+
+    // Delete confirmation state
+    const [deleteConfirmName, setDeleteConfirmName] = useState("");
+
+    // Mutations
+    const { mutate: updateOrg, isPending: isUpdating } = useUpdateOrganization();
+    const { mutate: updateMemberRole, isPending: isUpdatingRole } = useUpdateOrgMemberRole();
+    const { mutate: removeMember, isPending: isRemoving } = useRemoveOrgMember();
+    const { mutate: deleteOrg, isPending: isDeleting } = useDeleteOrganization();
+
+    // Sync form state with fetched data
+    useEffect(() => {
+        if (organization?.name) {
+            setOrgName(organization.name);
+        }
+    }, [organization?.name]);
+
+    // Detect changes
+    useEffect(() => {
+        if (organization?.name) {
+            setHasChanges(orgName !== organization.name);
+        }
+    }, [orgName, organization?.name]);
+
+    const members = membersData?.documents || [];
+    const ownerCount = members.filter((m: OrgMember) => m.role === "OWNER").length;
+
+    // Handler: Save organization changes
+    const handleSaveOrg = () => {
+        if (!primaryOrganizationId || !hasChanges) return;
+        updateOrg({
+            organizationId: primaryOrganizationId,
+            name: orgName,
+        });
+    };
+
+    // Handler: Update member role
+    const handleUpdateRole = (userId: string, newRole: OrganizationRole) => {
+        if (!primaryOrganizationId) return;
+        updateMemberRole({
+            organizationId: primaryOrganizationId,
+            userId,
+            role: newRole,
+        });
+    };
+
+    // Handler: Remove member
+    const handleRemoveMember = (userId: string) => {
+        if (!primaryOrganizationId) return;
+        removeMember({
+            organizationId: primaryOrganizationId,
+            userId,
+        });
+    };
+
+    // Handler: Delete organization
+    const handleDeleteOrg = () => {
+        if (!primaryOrganizationId) return;
+        deleteOrg({ organizationId: primaryOrganizationId });
+    };
+
+    const canDeleteOrg = isOwner && deleteConfirmName === organization?.name;
 
     if (!isOrg) {
         return (
@@ -63,6 +156,8 @@ export const OrganizationSettingsClient = () => {
         );
     }
 
+    const isLoading = isLoadingOrg || isLoadingRole;
+
     return (
         <div className="flex flex-col gap-6 p-6">
             {/* Header */}
@@ -70,9 +165,13 @@ export const OrganizationSettingsClient = () => {
                 <div className="flex items-center gap-3">
                     <Building2 className="h-8 w-8 text-primary" />
                     <div>
-                        <h1 className="text-2xl font-bold">
-                            {(currentOrg as { name?: string })?.name || "Organization Settings"}
-                        </h1>
+                        {isLoadingOrg ? (
+                            <Skeleton className="h-8 w-48" />
+                        ) : (
+                            <h1 className="text-2xl font-bold">
+                                {organization?.name || "Organization Settings"}
+                            </h1>
+                        )}
                         <p className="text-muted-foreground">
                             Manage your organization settings, members, and billing
                         </p>
@@ -85,7 +184,7 @@ export const OrganizationSettingsClient = () => {
 
             {/* Tabs */}
             <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-                <TabsList className="grid w-full grid-cols-4">
+                <TabsList className="grid w-full grid-cols-5">
                     <TabsTrigger value="general">
                         <Settings2 className="h-4 w-4 mr-2" />
                         General
@@ -102,47 +201,84 @@ export const OrganizationSettingsClient = () => {
                         <CreditCard className="h-4 w-4 mr-2" />
                         Billing
                     </TabsTrigger>
+                    <TabsTrigger value="audit">
+                        <FileText className="h-4 w-4 mr-2" />
+                        Audit
+                    </TabsTrigger>
                 </TabsList>
 
-                {/* General Tab */}
+                {/* ==================== GENERAL TAB ==================== */}
                 <TabsContent value="general" className="space-y-4 mt-6">
-
-                    {/* Organization Details */}
                     <Card>
                         <CardHeader>
                             <CardTitle className="flex items-center gap-2">
                                 <Settings2 className="h-5 w-5" />
                                 Organization Details
                             </CardTitle>
+                            <CardDescription>
+                                {canEdit
+                                    ? "Update your organization information"
+                                    : "View your organization information"}
+                            </CardDescription>
                         </CardHeader>
                         <CardContent className="space-y-4">
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                <div className="space-y-2">
-                                    <Label htmlFor="orgName">Organization Name</Label>
-                                    <Input
-                                        id="orgName"
-                                        defaultValue={(currentOrg as { name?: string })?.name || ""}
-                                        placeholder="Organization name"
-                                    />
+                            {isLoading ? (
+                                <div className="space-y-4">
+                                    <Skeleton className="h-10 w-full" />
+                                    <Skeleton className="h-10 w-full" />
                                 </div>
-                                <div className="space-y-2">
-                                    <Label htmlFor="orgId">Organization ID</Label>
-                                    <Input
-                                        id="orgId"
-                                        value={primaryOrganizationId || ""}
-                                        disabled
-                                        className="font-mono text-sm"
-                                    />
-                                </div>
-                            </div>
-                            <Button>Save Changes</Button>
+                            ) : (
+                                <>
+                                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                        <div className="space-y-2">
+                                            <Label htmlFor="orgName">Organization Name</Label>
+                                            <Input
+                                                id="orgName"
+                                                value={orgName}
+                                                onChange={(e) => setOrgName(e.target.value)}
+                                                placeholder="Organization name"
+                                                disabled={!canEdit}
+                                            />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label htmlFor="orgId">Organization ID</Label>
+                                            <Input
+                                                id="orgId"
+                                                value={primaryOrganizationId || ""}
+                                                disabled
+                                                className="font-mono text-sm"
+                                            />
+                                        </div>
+                                    </div>
+                                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                        <div className="space-y-2">
+                                            <Label>Created</Label>
+                                            <Input
+                                                value={organization?.$createdAt
+                                                    ? format(new Date(organization.$createdAt), "MMM d, yyyy")
+                                                    : "-"
+                                                }
+                                                disabled
+                                            />
+                                        </div>
+                                    </div>
+                                    {canEdit && (
+                                        <Button
+                                            onClick={handleSaveOrg}
+                                            disabled={!hasChanges || isUpdating}
+                                        >
+                                            {isUpdating && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+                                            Save Changes
+                                        </Button>
+                                    )}
+                                </>
+                            )}
                         </CardContent>
                     </Card>
                 </TabsContent>
 
-                {/* Members Tab */}
+                {/* ==================== MEMBERS TAB ==================== */}
                 <TabsContent value="members" className="space-y-4 mt-6">
-                    {/* Members Management */}
                     <Card>
                         <CardHeader>
                             <div className="flex items-center justify-between">
@@ -152,102 +288,131 @@ export const OrganizationSettingsClient = () => {
                                         Organization Members
                                     </CardTitle>
                                     <CardDescription>
-                                        Manage who has access to your organization
+                                        {members.length} member{members.length !== 1 ? "s" : ""} in your organization
                                     </CardDescription>
                                 </div>
-                                <Dialog>
-                                    <DialogTrigger asChild>
-                                        <Button size="sm">
-                                            <UserPlus className="h-4 w-4 mr-2" />
-                                            Invite Member
-                                        </Button>
-                                    </DialogTrigger>
-                                    <DialogContent>
-                                        <DialogHeader>
-                                            <DialogTitle>Invite Member</DialogTitle>
-                                            <DialogDescription>
-                                                Add a new member to your organization
-                                            </DialogDescription>
-                                        </DialogHeader>
-                                        <div className="space-y-4 py-4">
-                                            <div className="space-y-2">
-                                                <Label htmlFor="email">Email Address</Label>
-                                                <Input
-                                                    id="email"
-                                                    placeholder="member@example.com"
-                                                    type="email"
-                                                    value={inviteEmail}
-                                                    onChange={(e) => setInviteEmail(e.target.value)}
-                                                />
-                                            </div>
-                                            <div className="space-y-2">
-                                                <Label htmlFor="role">Role</Label>
-                                                <Select value={inviteRole} onValueChange={(v) => setInviteRole(v as OrganizationRole)}>
-                                                    <SelectTrigger>
-                                                        <SelectValue placeholder="Select role" />
-                                                    </SelectTrigger>
-                                                    <SelectContent>
-                                                        <SelectItem value={OrganizationRole.MEMBER}>Member</SelectItem>
-                                                        <SelectItem value={OrganizationRole.ADMIN}>Admin</SelectItem>
-                                                        <SelectItem value={OrganizationRole.OWNER}>Owner</SelectItem>
-                                                    </SelectContent>
-                                                </Select>
-                                            </div>
-                                        </div>
-                                        <DialogFooter>
-                                            <Button type="submit">Send Invite</Button>
-                                        </DialogFooter>
-                                    </DialogContent>
-                                </Dialog>
+                                {/* Note: Invite functionality requires email-based invitation system */}
                             </div>
                         </CardHeader>
                         <CardContent>
-                            <div className="space-y-3">
-                                {members.map((member) => (
-                                    <div
-                                        key={member.id}
-                                        className="flex items-center justify-between p-3 rounded-lg border"
-                                    >
-                                        <div className="flex items-center gap-3">
-                                            <Avatar className="h-10 w-10">
-                                                <AvatarImage src={member.avatar || undefined} />
-                                                <AvatarFallback>
-                                                    {member.name.split(" ").map(n => n[0]).join("")}
-                                                </AvatarFallback>
-                                            </Avatar>
-                                            <div>
-                                                <div className="flex items-center gap-2">
-                                                    <span className="font-medium">{member.name}</span>
-                                                    {member.role === "OWNER" && (
-                                                        <Crown className="h-4 w-4 text-yellow-500" />
-                                                    )}
+                            {isLoadingMembers ? (
+                                <div className="space-y-3">
+                                    {[1, 2, 3].map((i) => (
+                                        <div key={i} className="flex items-center gap-3 p-3 border rounded-lg">
+                                            <Skeleton className="h-10 w-10 rounded-full" />
+                                            <div className="flex-1 space-y-2">
+                                                <Skeleton className="h-4 w-32" />
+                                                <Skeleton className="h-3 w-48" />
+                                            </div>
+                                            <Skeleton className="h-6 w-16" />
+                                        </div>
+                                    ))}
+                                </div>
+                            ) : (
+                                <div className="space-y-3">
+                                    {members.map((member: OrgMember) => (
+                                        <div
+                                            key={member.$id}
+                                            className="flex items-center justify-between p-3 rounded-lg border"
+                                        >
+                                            <div className="flex items-center gap-3">
+                                                <Avatar className="h-10 w-10">
+                                                    <AvatarImage src={member.profileImageUrl || undefined} />
+                                                    <AvatarFallback>
+                                                        {(member.name || member.email || "?")
+                                                            .split(" ")
+                                                            .map(n => n[0])
+                                                            .join("")
+                                                            .toUpperCase()
+                                                            .slice(0, 2)}
+                                                    </AvatarFallback>
+                                                </Avatar>
+                                                <div>
+                                                    <div className="flex items-center gap-2">
+                                                        <span className="font-medium">
+                                                            {member.name || member.email || "Unknown"}
+                                                        </span>
+                                                        {member.role === "OWNER" && (
+                                                            <Crown className="h-4 w-4 text-yellow-500" />
+                                                        )}
+                                                    </div>
+                                                    <span className="text-sm text-muted-foreground">
+                                                        {member.email || member.userId}
+                                                    </span>
                                                 </div>
-                                                <span className="text-sm text-muted-foreground">{member.email}</span>
+                                            </div>
+                                            <div className="flex items-center gap-2">
+                                                {/* Role selector (ADMIN+ can change roles) */}
+                                                {canEdit ? (
+                                                    <Select
+                                                        value={member.role}
+                                                        onValueChange={(value) =>
+                                                            handleUpdateRole(member.userId, value as OrganizationRole)
+                                                        }
+                                                        disabled={isUpdatingRole || (member.role === "OWNER" && ownerCount === 1)}
+                                                    >
+                                                        <SelectTrigger className="w-28">
+                                                            <SelectValue />
+                                                        </SelectTrigger>
+                                                        <SelectContent>
+                                                            <SelectItem value="OWNER">Owner</SelectItem>
+                                                            <SelectItem value="ADMIN">Admin</SelectItem>
+                                                            <SelectItem value="MEMBER">Member</SelectItem>
+                                                        </SelectContent>
+                                                    </Select>
+                                                ) : (
+                                                    <Badge variant={
+                                                        member.role === "OWNER" ? "default" :
+                                                            member.role === "ADMIN" ? "secondary" : "outline"
+                                                    }>
+                                                        {member.role}
+                                                    </Badge>
+                                                )}
+
+                                                {/* Remove member (ADMIN+ can remove, but not last OWNER) */}
+                                                {canEdit && member.role !== "OWNER" && (
+                                                    <AlertDialog>
+                                                        <AlertDialogTrigger asChild>
+                                                            <Button
+                                                                variant="ghost"
+                                                                size="icon"
+                                                                className="h-8 w-8 text-destructive"
+                                                                disabled={isRemoving}
+                                                            >
+                                                                <Trash2 className="h-4 w-4" />
+                                                            </Button>
+                                                        </AlertDialogTrigger>
+                                                        <AlertDialogContent>
+                                                            <AlertDialogHeader>
+                                                                <AlertDialogTitle>Remove member?</AlertDialogTitle>
+                                                                <AlertDialogDescription>
+                                                                    This will remove {member.name || member.email} from the organization.
+                                                                    They will lose access to all organization resources.
+                                                                </AlertDialogDescription>
+                                                            </AlertDialogHeader>
+                                                            <AlertDialogFooter>
+                                                                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                                                                <AlertDialogAction
+                                                                    onClick={() => handleRemoveMember(member.userId)}
+                                                                    className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                                                                >
+                                                                    Remove
+                                                                </AlertDialogAction>
+                                                            </AlertDialogFooter>
+                                                        </AlertDialogContent>
+                                                    </AlertDialog>
+                                                )}
                                             </div>
                                         </div>
-                                        <div className="flex items-center gap-2">
-                                            <Badge variant={
-                                                member.role === "OWNER" ? "default" :
-                                                    member.role === "ADMIN" ? "secondary" : "outline"
-                                            }>
-                                                {member.role}
-                                            </Badge>
-                                            {member.role !== "OWNER" && (
-                                                <Button variant="ghost" size="icon" className="h-8 w-8 text-destructive">
-                                                    <Trash2 className="h-4 w-4" />
-                                                </Button>
-                                            )}
-                                        </div>
-                                    </div>
-                                ))}
-                            </div>
+                                    ))}
+                                </div>
+                            )}
                         </CardContent>
                     </Card>
                 </TabsContent>
 
-                {/* Security Tab */}
+                {/* ==================== SECURITY TAB (with Danger Zone) ==================== */}
                 <TabsContent value="security" className="space-y-4 mt-6">
-                    {/* Security & Permissions */}
                     <Card>
                         <CardHeader>
                             <CardTitle className="flex items-center gap-2">
@@ -266,7 +431,7 @@ export const OrganizationSettingsClient = () => {
                                         Who can create new workspaces in this organization
                                     </div>
                                 </div>
-                                <Select defaultValue="admins">
+                                <Select defaultValue="admins" disabled={!canEdit}>
                                     <SelectTrigger className="w-40">
                                         <SelectValue />
                                     </SelectTrigger>
@@ -284,7 +449,7 @@ export const OrganizationSettingsClient = () => {
                                         Who can invite new members to the organization
                                     </div>
                                 </div>
-                                <Select defaultValue="admins">
+                                <Select defaultValue="admins" disabled={!canEdit}>
                                     <SelectTrigger className="w-40">
                                         <SelectValue />
                                     </SelectTrigger>
@@ -297,41 +462,90 @@ export const OrganizationSettingsClient = () => {
                         </CardContent>
                     </Card>
 
-                    {/* Danger Zone - Soft Delete with Grace Period */}
-                    <Card className="border-destructive/50">
-                        <CardHeader>
-                            <CardTitle className="text-destructive flex items-center gap-2">
-                                <AlertTriangle className="h-5 w-5" />
-                                Danger Zone
-                            </CardTitle>
-                            <CardDescription>
-                                Organization deletion actions
-                            </CardDescription>
-                        </CardHeader>
-                        <CardContent>
-                            <div className="flex items-center justify-between p-3 rounded-lg border border-destructive/30 bg-destructive/5">
-                                <div>
-                                    <div className="font-medium">Delete Organization</div>
-                                    <div className="text-sm text-muted-foreground">
-                                        Data will be retained for 30 days before permanent deletion.
-                                        Billing will be frozen immediately.
+                    {/* Danger Zone - OWNER ONLY */}
+                    {isOwner && (
+                        <Card className="border-destructive/50">
+                            <CardHeader>
+                                <CardTitle className="text-destructive flex items-center gap-2">
+                                    <AlertTriangle className="h-5 w-5" />
+                                    Danger Zone
+                                </CardTitle>
+                                <CardDescription>
+                                    Irreversible and destructive actions
+                                </CardDescription>
+                            </CardHeader>
+                            <CardContent>
+                                <div className="flex items-center justify-between p-3 rounded-lg border border-destructive/30 bg-destructive/5">
+                                    <div>
+                                        <div className="font-medium">Delete Organization</div>
+                                        <div className="text-sm text-muted-foreground">
+                                            Data will be retained for 30 days before permanent deletion.
+                                            Billing will be frozen immediately.
+                                        </div>
                                     </div>
+                                    <Dialog>
+                                        <DialogTrigger asChild>
+                                            <Button variant="destructive" size="sm">
+                                                <Trash2 className="h-4 w-4 mr-2" />
+                                                Delete
+                                            </Button>
+                                        </DialogTrigger>
+                                        <DialogContent>
+                                            <DialogHeader>
+                                                <DialogTitle className="text-destructive">
+                                                    Delete Organization
+                                                </DialogTitle>
+                                                <DialogDescription>
+                                                    This action cannot be undone. This will permanently delete the
+                                                    organization and all associated data after 30 days.
+                                                </DialogDescription>
+                                            </DialogHeader>
+                                            <div className="space-y-4 py-4">
+                                                <div className="space-y-2">
+                                                    <Label>
+                                                        Type <strong>{organization?.name}</strong> to confirm:
+                                                    </Label>
+                                                    <Input
+                                                        value={deleteConfirmName}
+                                                        onChange={(e) => setDeleteConfirmName(e.target.value)}
+                                                        placeholder="Organization name"
+                                                    />
+                                                </div>
+                                            </div>
+                                            <DialogFooter>
+                                                <DialogClose asChild>
+                                                    <Button variant="outline">Cancel</Button>
+                                                </DialogClose>
+                                                <Button
+                                                    variant="destructive"
+                                                    onClick={handleDeleteOrg}
+                                                    disabled={!canDeleteOrg || isDeleting}
+                                                >
+                                                    {isDeleting && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+                                                    Delete Organization
+                                                </Button>
+                                            </DialogFooter>
+                                        </DialogContent>
+                                    </Dialog>
                                 </div>
-                                <Button variant="destructive" size="sm">
-                                    <Trash2 className="h-4 w-4 mr-2" />
-                                    Delete
-                                </Button>
-                            </div>
-                        </CardContent>
-                    </Card>
+                            </CardContent>
+                        </Card>
+                    )}
                 </TabsContent>
 
-                {/* Billing Tab */}
+                {/* ==================== BILLING TAB ==================== */}
                 <TabsContent value="billing" className="space-y-4 mt-6">
                     <OrganizationBillingSettings
                         organizationId={primaryOrganizationId || ""}
-                        organizationName={(currentOrg as { name?: string })?.name || "Organization"}
+                        organizationName={organization?.name || "Organization"}
                     />
+                </TabsContent>
+
+                {/* ==================== AUDIT TAB (OWNER ONLY) ==================== */}
+                <TabsContent value="audit" className="space-y-4 mt-6">
+                    {primaryOrganizationId && (
+                        <OrganizationAuditLogs organizationId={primaryOrganizationId} />
+                    )}
                 </TabsContent>
             </Tabs>
         </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,7 +10,8 @@ export default async function Home() {
     const workspaces = await getWorkspaces();
 
     if (workspaces.total === 0) {
-      redirect("/workspaces/create");
+      // Zero-workspace state: show welcome page instead of forcing workspace creation
+      redirect("/welcome");
     } else {
       redirect(`/workspaces/${workspaces.documents[0].$id}`);
     }
@@ -18,3 +19,4 @@ export default async function Home() {
 
   redirect("/sign-in");
 }
+

--- a/src/components/global-app-loader.tsx
+++ b/src/components/global-app-loader.tsx
@@ -39,11 +39,11 @@ export const GlobalAppLoader = () => {
                 {/* Message */}
                 <div className="text-center">
                     <p className="text-lg font-medium text-foreground">
-                        {isTimedOut ? "This is taking longer than expected" : loadingMessage}
+                        {isTimedOut ? "This may take a bit longer on first login or slow connections" : loadingMessage}
                     </p>
                     {isTimedOut && (
                         <p className="text-sm text-muted-foreground mt-2">
-                            There might be a connection issue.
+                            Please wait a moment, or try again if the issue persists.
                         </p>
                     )}
                 </div>

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -15,55 +15,69 @@ import { useCurrentMember } from "@/features/members/hooks/use-current-member";
 import { useWorkspaceId } from "@/features/workspaces/hooks/use-workspace-id";
 import { useProjectId } from "@/features/projects/hooks/use-project-id";
 import { useAccountType } from "@/features/organizations/hooks/use-account-type";
+import { useCurrentOrgMember } from "@/features/organizations/api/use-current-org-member";
 
+/**
+ * Route configuration with scope distinction:
+ * - workspaceScoped: true = requires active workspace (hidden when no workspace)
+ * - orgRoute: true = uses dashboard-level route (not workspace-prefixed)
+ */
 const routes = [
   {
     label: "Home",
     href: "",
     icon: GoHome,
     activeIcon: GoHomeFill,
+    workspaceScoped: true, // Only available when workspace exists
   },
   {
     label: "My Spaces",
     href: "/tasks",
     icon: GoCheckCircle,
     activeIcon: GoCheckCircleFill,
+    workspaceScoped: true,
   },
   {
     label: "Programs",
     href: "/programs",
     icon: FolderKanban,
     activeIcon: FolderKanban,
+    workspaceScoped: true,
   },
   {
     label: "Spaces",
     href: "/spaces",
     icon: Layers,
     activeIcon: Layers,
+    workspaceScoped: true,
   },
   {
     label: "Teams",
     href: "/teams",
     icon: Users2,
     activeIcon: Users2,
+    workspaceScoped: true,
   },
   {
     label: "Timeline",
     href: "/timeline",
     icon: Calendar,
     activeIcon: Calendar,
+    workspaceScoped: true,
   },
   {
     label: "Time Tracking",
     href: "/time-tracking",
     icon: ClockIcon,
     activeIcon: ClockIcon,
+    workspaceScoped: true,
   },
   {
     label: "Audit Log",
     href: "/audit-logs",
     icon: Activity,
     activeIcon: Activity,
+    workspaceScoped: true,
   },
   {
     label: "Admin Panel",
@@ -71,6 +85,7 @@ const routes = [
     icon: Shield,
     activeIcon: Shield,
     adminOnly: true,
+    workspaceScoped: true,
   },
   {
     label: "Billing",
@@ -78,6 +93,7 @@ const routes = [
     icon: CreditCard,
     activeIcon: CreditCard,
     adminOnly: true,
+    workspaceScoped: true,
   },
   {
     label: "Organization",
@@ -85,36 +101,49 @@ const routes = [
     icon: Building2,
     activeIcon: Building2,
     orgOnly: true, // Only show for ORG accounts
-    adminOnly: true,
+    orgAdminOnly: true, // Requires org admin/owner role
+    orgRoute: true, // Uses dashboard-level route (not workspace-prefixed)
   },
   {
     label: "Settings",
     href: "/settings",
     icon: Settings,
     activeIcon: Settings,
+    workspaceScoped: true,
   },
   {
     label: "Members",
     href: "/members",
     icon: User,
     activeIcon: User,
+    workspaceScoped: true,
   },
-  // Roles are now managed within Teams (project-scoped RBAC)
 ];
 
-export const Navigation = () => {
+interface NavigationProps {
+  hasWorkspaces?: boolean;
+}
+
+export const Navigation = ({ hasWorkspaces = true }: NavigationProps) => {
   const workspaceId = useWorkspaceId();
   const projectId = useProjectId();
   const pathname = usePathname();
   const { isAdmin } = useCurrentMember({ workspaceId });
-  const { isOrg } = useAccountType();
+  const { isOrg, primaryOrganizationId } = useAccountType();
+  const { canEdit: isOrgAdmin } = useCurrentOrgMember({
+    organizationId: primaryOrganizationId || ""
+  });
 
-  // Filter routes based on permissions and account type
+  // Filter routes based on permissions, account type, and workspace existence
   const visibleRoutes = routes.filter(route => {
-    // Hide admin-only routes for non-admins
-    if (route.adminOnly && !isAdmin) return false;
+    // Hide workspace-scoped routes when no workspace exists
+    if (route.workspaceScoped && !hasWorkspaces) return false;
+    // Hide workspace admin-only routes for non-admins (when in workspace context)
+    if (route.adminOnly && hasWorkspaces && !isAdmin) return false;
     // Hide org-only routes for PERSONAL accounts
     if (route.orgOnly && !isOrg) return false;
+    // Hide org admin-only routes for non org-admins
+    if (route.orgAdminOnly && !isOrgAdmin) return false;
     return true;
   });
 
@@ -122,16 +151,28 @@ export const Navigation = () => {
     <div className="p-3 border-b-[1.5px] border-neutral-200 flex-shrink-0">
       <ul className="flex flex-col ">
         {visibleRoutes.map((item) => {
-          // For timeline, pass workspaceId and projectId (if available) as search params for SSR
-          const fullHref = item.href === "/timeline"
-            ? `/workspaces/${workspaceId}${item.href}?workspaceId=${workspaceId}${projectId ? `&projectId=${projectId}` : ""}`
-            : `/workspaces/${workspaceId}${item.href}`;
-          const isActive = pathname === `/workspaces/${workspaceId}${item.href}`;
+          // Determine the correct href based on route type
+          let fullHref: string;
+          let isActive: boolean;
+
+          if (item.orgRoute) {
+            // Org-level routes: dashboard-level, no workspace prefix
+            fullHref = item.href;
+            isActive = pathname === item.href;
+          } else if (item.href === "/timeline") {
+            // Timeline: pass workspaceId and projectId as search params for SSR
+            fullHref = `/workspaces/${workspaceId}${item.href}?workspaceId=${workspaceId}${projectId ? `&projectId=${projectId}` : ""}`;
+            isActive = pathname === `/workspaces/${workspaceId}${item.href}`;
+          } else {
+            // Standard workspace-scoped routes
+            fullHref = `/workspaces/${workspaceId}${item.href}`;
+            isActive = pathname === `/workspaces/${workspaceId}${item.href}`;
+          }
+
           const Icon = isActive ? item.activeIcon : item.icon;
 
           return (
-            <div key={item.href}>
-
+            <div key={item.href || item.label}>
               <Link href={fullHref}>
                 <div
                   className={cn(
@@ -146,11 +187,10 @@ export const Navigation = () => {
                 </div>
               </Link>
             </div>
-
           );
         })}
       </ul>
     </div>
-
   );
 };
+

--- a/src/components/onboarding-stepper.tsx
+++ b/src/components/onboarding-stepper.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { Check } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Onboarding Stepper Component
+ * 
+ * Visual representation of the onboarding progress.
+ * Shows steps as completed, active, or pending.
+ * 
+ * PERSONAL accounts: Steps 1-2 only
+ * ORG accounts: Steps 1-5
+ */
+
+export enum OnboardingStep {
+    SIGNUP = 1,
+    EMAIL_VERIFICATION = 2,
+    ORG_SETUP = 3,
+    WORKSPACE_SETUP = 4,
+    COMPLETED = 5,
+}
+
+interface Step {
+    id: number;
+    name: string;
+    description: string;
+}
+
+const PERSONAL_STEPS: Step[] = [
+    { id: 1, name: "Account", description: "Create your account" },
+    { id: 2, name: "Verify Email", description: "Confirm your email" },
+];
+
+const ORG_STEPS: Step[] = [
+    { id: 1, name: "Account", description: "Create your account" },
+    { id: 2, name: "Verify Email", description: "Confirm your email" },
+    { id: 3, name: "Organization", description: "Set up your organization" },
+    { id: 4, name: "Workspace", description: "Create a workspace" },
+    { id: 5, name: "Complete", description: "Enter the app" },
+];
+
+interface OnboardingStepperProps {
+    currentStep: OnboardingStep;
+    accountType: "PERSONAL" | "ORG";
+    className?: string;
+}
+
+export function OnboardingStepper({
+    currentStep,
+    accountType,
+    className
+}: OnboardingStepperProps) {
+    const steps = accountType === "ORG" ? ORG_STEPS : PERSONAL_STEPS;
+
+    return (
+        <nav aria-label="Progress" className={cn("w-full", className)}>
+            <ol className="flex items-center justify-center gap-2">
+                {steps.map((step, index) => {
+                    const isCompleted = step.id < currentStep;
+                    const isActive = step.id === currentStep;
+                    const isPending = step.id > currentStep;
+
+                    return (
+                        <li
+                            key={step.id}
+                            className="flex items-center"
+                        >
+                            {/* Step indicator */}
+                            <div className="flex flex-col items-center">
+                                <div
+                                    className={cn(
+                                        "flex h-10 w-10 items-center justify-center rounded-full border-2 font-medium transition-colors",
+                                        isCompleted && "border-primary bg-primary text-primary-foreground",
+                                        isActive && "border-primary bg-primary/10 text-primary",
+                                        isPending && "border-muted-foreground/30 bg-muted/50 text-muted-foreground"
+                                    )}
+                                >
+                                    {isCompleted ? (
+                                        <Check className="h-5 w-5" />
+                                    ) : (
+                                        <span>{step.id}</span>
+                                    )}
+                                </div>
+                                <div className="mt-2 text-center">
+                                    <p
+                                        className={cn(
+                                            "text-sm font-medium",
+                                            isActive && "text-primary",
+                                            isPending && "text-muted-foreground"
+                                        )}
+                                    >
+                                        {step.name}
+                                    </p>
+                                </div>
+                            </div>
+
+                            {/* Connector line */}
+                            {index < steps.length - 1 && (
+                                <div
+                                    className={cn(
+                                        "mx-2 h-0.5 w-8 sm:w-12",
+                                        step.id < currentStep
+                                            ? "bg-primary"
+                                            : "bg-muted-foreground/30"
+                                    )}
+                                />
+                            )}
+                        </li>
+                    );
+                })}
+            </ol>
+        </nav>
+    );
+}
+
+/**
+ * Compact version for smaller spaces
+ */
+export function OnboardingStepperCompact({
+    currentStep,
+    accountType,
+}: OnboardingStepperProps) {
+    const steps = accountType === "ORG" ? ORG_STEPS : PERSONAL_STEPS;
+    const currentStepData = steps.find((s) => s.id === currentStep);
+
+    return (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <span className="font-medium text-foreground">
+                Step {currentStep} of {steps.length}
+            </span>
+            <span>•</span>
+            <span>{currentStepData?.name}</span>
+        </div>
+    );
+}

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Image from "next/image";
 import Link from "next/link";
 
@@ -5,25 +7,61 @@ import { Navigation } from "./navigation";
 import { WorkspaceSwitcher } from "./workspace-switcher";
 import { Projects } from "./projects";
 import { Spaces } from "./spaces";
+import { useGetWorkspaces } from "@/features/workspaces/api/use-get-workspaces";
+import { useWorkspaceId } from "@/features/workspaces/hooks/use-workspace-id";
+import { useAccountType } from "@/features/organizations/hooks/use-account-type";
 
 export const Sidebar = () => {
+  const { data: workspaces } = useGetWorkspaces();
+  const workspaceId = useWorkspaceId();
+  const { isOrg } = useAccountType();
+
+  const hasWorkspaces = workspaces && workspaces.total > 0;
+  const hasActiveWorkspace = hasWorkspaces && !!workspaceId;
+
   return (
     <aside className="h-full bg-neutral-50 w-full overflow-hidden border-r-[1.5px] border-neutral-200 flex flex-col">
       <div className="flex items-center w-full py-5 px-4 border-b-[1.5px] border-neutral-200 flex-shrink-0">
-        <Link href="/" >
+        <Link href={hasWorkspaces ? "/" : "/welcome"} >
           <Image src="/Logo.png" className="object-contain " alt="logo" width={80} height={90} />
         </Link>
       </div>
-      
+
       <div className="flex flex-col flex-1 overflow-hidden overflow-y-auto">
-        <Navigation />
-        <Projects />
-        <Spaces />
+        {/* Navigation: Always shown for ORG accounts, or when workspaces exist for PERSONAL */}
+        {(isOrg || hasWorkspaces) && (
+          <Navigation hasWorkspaces={hasWorkspaces} />
+        )}
+
+        {/* Workspace-scoped content: Only shown when a workspace is actively selected */}
+        {hasActiveWorkspace && (
+          <>
+            <Projects />
+            <Spaces />
+          </>
+        )}
+
+        {/* Empty state: Only for PERSONAL accounts with no workspaces */}
+        {!hasWorkspaces && !isOrg && (
+          <div className="p-4 text-center text-sm text-muted-foreground">
+            <p className="mb-2">No workspaces yet</p>
+            <p>Create a workspace to get started</p>
+          </div>
+        )}
+
+        {/* ORG accounts with no workspaces - show guidance */}
+        {!hasWorkspaces && isOrg && (
+          <div className="p-4 text-center text-sm text-muted-foreground">
+            <p className="mb-2">Ready to start</p>
+            <p>Create a workspace or manage your organization</p>
+          </div>
+        )}
       </div>
-     
+
       <div className="flex-shrink-0">
         <WorkspaceSwitcher />
       </div>
     </aside>
   );
 };
+

--- a/src/features/auth/api/use-logout.ts
+++ b/src/features/auth/api/use-logout.ts
@@ -19,8 +19,10 @@ export const useLogout = () => {
     },
     onSuccess: () => {
       toast.success("Logged out.");
-      router.refresh();
-      queryClient.invalidateQueries();
+      // Clear all cached queries
+      queryClient.clear();
+      // Redirect to sign-in page
+      router.push("/sign-in");
     },
     onError: () => {
       toast.error("Failed to log out.");
@@ -29,3 +31,4 @@ export const useLogout = () => {
 
   return mutation;
 };
+

--- a/src/features/auth/api/use-verify-email.ts
+++ b/src/features/auth/api/use-verify-email.ts
@@ -1,5 +1,5 @@
 import { toast } from "sonner";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { InferRequestType, InferResponseType } from "hono";
 import { useRouter } from "next/navigation";
 
@@ -12,8 +12,17 @@ type RequestType = InferRequestType<
   (typeof client.api.auth)["verify-email"]["$post"]
 >;
 
+/**
+ * Verify email and auto-authenticate hook
+ * 
+ * After successful verification:
+ * - Backend creates session and sets cookie
+ * - User is auto-logged in
+ * - Redirects directly to onboarding/dashboard based on account type
+ */
 export const useVerifyEmail = () => {
   const router = useRouter();
+  const queryClient = useQueryClient();
 
   const mutation = useMutation<ResponseType, Error, RequestType>({
     mutationFn: async ({ json }) => {
@@ -22,8 +31,32 @@ export const useVerifyEmail = () => {
     },
     onSuccess: (data) => {
       if ('success' in data && data.success) {
-        toast.success('message' in data && data.message ? String(data.message) : "Email verified successfully!");
-        router.push("/sign-in");
+        // Clear any stale cache before redirecting
+        queryClient.clear();
+
+        // Check if auto-authenticated
+        const autoAuthenticated = 'autoAuthenticated' in data && data.autoAuthenticated;
+        const accountType = 'accountType' in data ? data.accountType : "PERSONAL";
+        const orgSetupComplete = 'orgSetupComplete' in data ? data.orgSetupComplete : false;
+
+        if (autoAuthenticated) {
+          // Session was created - redirect directly to appropriate route
+          toast.success("Email verified!", {
+            description: "Welcome! Taking you to your dashboard...",
+          });
+
+          if (accountType === "ORG" && !orgSetupComplete) {
+            router.push("/onboarding/organization");
+          } else {
+            router.push("/");
+          }
+        } else {
+          // Fallback: redirect to sign-in
+          toast.success("Email verified!", {
+            description: "Please log in to continue.",
+          });
+          router.push("/sign-in");
+        }
       } else if ('error' in data && data.error) {
         toast.error(String(data.error));
       }

--- a/src/features/auth/components/sign-up-card.tsx
+++ b/src/features/auth/components/sign-up-card.tsx
@@ -169,7 +169,7 @@ export const SignUpCard = ({ returnUrl }: SignUpCardProps) => {
                 </FormItem>
               )}
             />
-            <Button disabled={isPending} size="lg" className="w-full">
+            <Button type="submit" disabled={isPending} size="lg" className="w-full">
               Sign Up
             </Button>
           </form>

--- a/src/features/members/api/use-get-members.ts
+++ b/src/features/members/api/use-get-members.ts
@@ -5,9 +5,10 @@ import { QUERY_CONFIG } from "@/lib/query-config";
 
 interface useGetMembersProps {
   workspaceId: string;
+  enabled?: boolean;
 }
 
-export const useGetMembers = ({ workspaceId }: useGetMembersProps) => {
+export const useGetMembers = ({ workspaceId, enabled = true }: useGetMembersProps) => {
   const query = useQuery({
     queryKey: ["members", workspaceId],
     staleTime: QUERY_CONFIG.SEMI_DYNAMIC.staleTime,
@@ -25,7 +26,9 @@ export const useGetMembers = ({ workspaceId }: useGetMembersProps) => {
 
       return data;
     },
+    enabled: enabled && Boolean(workspaceId),
   });
 
   return query;
 };
+

--- a/src/features/members/hooks/use-current-member.ts
+++ b/src/features/members/hooks/use-current-member.ts
@@ -8,22 +8,37 @@ interface UseCurrentMemberProps {
 
 export const useCurrentMember = ({ workspaceId }: UseCurrentMemberProps) => {
   const { data: user } = useCurrent();
-  const { data: members } = useGetMembers({ workspaceId });
+  // Only fetch members when we have a valid workspaceId
+  const hasWorkspace = Boolean(workspaceId);
+  const { data: members, isLoading: isMembersLoading } = useGetMembers({
+    workspaceId: workspaceId || "",
+    enabled: hasWorkspace,
+  });
+
+  // If no workspace, return defaults without loading state
+  if (!hasWorkspace) {
+    return {
+      member: null,
+      isAdmin: false,
+      isLoading: false
+    };
+  }
 
   if (!user || !members) {
-    return { 
-      member: null, 
-      isAdmin: false, 
-      isLoading: true 
+    return {
+      member: null,
+      isAdmin: false,
+      isLoading: isMembersLoading
     };
   }
 
   const member = members.documents.find(m => m.userId === user.$id);
   const isAdmin = member?.role === MemberRole.ADMIN;
 
-  return { 
-    member, 
-    isAdmin, 
-    isLoading: false 
+  return {
+    member,
+    isAdmin,
+    isLoading: false
   };
 };
+

--- a/src/features/notifications/api/use-get-notifications.ts
+++ b/src/features/notifications/api/use-get-notifications.ts
@@ -5,12 +5,14 @@ interface UseGetNotificationsProps {
   workspaceId: string;
   limit?: number;
   unreadOnly?: boolean;
+  enabled?: boolean;
 }
 
 export const useGetNotifications = ({
   workspaceId,
   limit = 50,
   unreadOnly = false,
+  enabled = true,
 }: UseGetNotificationsProps) => {
   const query = useQuery({
     queryKey: ["notifications", workspaceId, limit, unreadOnly],
@@ -30,9 +32,11 @@ export const useGetNotifications = ({
       const { data } = await response.json();
       return data;
     },
-    refetchInterval: 30000, // Refetch every 30 seconds
+    enabled: enabled && Boolean(workspaceId),
+    refetchInterval: enabled ? 30000 : false, // Refetch every 30 seconds when enabled
     refetchIntervalInBackground: true, // Continue refetching even when window is not focused
   });
 
   return query;
 };
+

--- a/src/features/notifications/api/use-get-unread-count.ts
+++ b/src/features/notifications/api/use-get-unread-count.ts
@@ -3,9 +3,10 @@ import { client } from "@/lib/rpc";
 
 interface UseGetUnreadCountProps {
   workspaceId: string;
+  enabled?: boolean;
 }
 
-export const useGetUnreadCount = ({ workspaceId }: UseGetUnreadCountProps) => {
+export const useGetUnreadCount = ({ workspaceId, enabled = true }: UseGetUnreadCountProps) => {
   const query = useQuery({
     queryKey: ["notifications", "unread-count", workspaceId],
     queryFn: async () => {
@@ -20,9 +21,11 @@ export const useGetUnreadCount = ({ workspaceId }: UseGetUnreadCountProps) => {
       const { data } = await response.json();
       return data;
     },
-    refetchInterval: 30000, // Refetch every 30 seconds
+    enabled: enabled && Boolean(workspaceId),
+    refetchInterval: enabled ? 30000 : false, // Refetch every 30 seconds when enabled
     refetchIntervalInBackground: true, // Continue refetching even when window is not focused
   });
 
   return query;
 };
+

--- a/src/features/onboarding/hooks/use-onboarding-state.ts
+++ b/src/features/onboarding/hooks/use-onboarding-state.ts
@@ -1,0 +1,96 @@
+"use client";
+
+import { useCurrent } from "@/features/auth/api/use-current";
+import { OnboardingStep } from "@/components/onboarding-stepper";
+
+/**
+ * Onboarding State Hook
+ * 
+ * Provides current onboarding step derived from user prefs and verification status.
+ * 
+ * State derivation logic:
+ * - No emailVerification → EMAIL_VERIFICATION step
+ * - ORG account without orgSetupComplete → ORG_SETUP step
+ * - ORG account without workspace → WORKSPACE_SETUP step
+ * - Otherwise → COMPLETED
+ */
+
+export interface OnboardingState {
+    currentStep: OnboardingStep;
+    accountType: "PERSONAL" | "ORG";
+    isComplete: boolean;
+    isLoading: boolean;
+    requiredRoute: string | null;
+}
+
+export function useOnboardingState(): OnboardingState {
+    const { data: user, isLoading } = useCurrent();
+
+    if (isLoading || !user) {
+        return {
+            currentStep: OnboardingStep.SIGNUP,
+            accountType: "PERSONAL",
+            isComplete: false,
+            isLoading: true,
+            requiredRoute: null,
+        };
+    }
+
+    const prefs = user.prefs || {};
+    const accountType: "PERSONAL" | "ORG" = prefs.accountType || "PERSONAL";
+    const emailVerified = user.emailVerification === true;
+    const orgSetupComplete = prefs.orgSetupComplete === true;
+    const primaryOrganizationId = prefs.primaryOrganizationId;
+
+    // Derive current step from state
+    let currentStep: OnboardingStep;
+    let requiredRoute: string | null = null;
+
+    if (!emailVerified) {
+        currentStep = OnboardingStep.EMAIL_VERIFICATION;
+        requiredRoute = "/verify-email-needed";
+    } else if (accountType === "ORG" && !orgSetupComplete) {
+        currentStep = OnboardingStep.ORG_SETUP;
+        requiredRoute = "/onboarding/organization";
+    } else if (accountType === "ORG" && !primaryOrganizationId) {
+        // Edge case: verified but no org created yet
+        currentStep = OnboardingStep.ORG_SETUP;
+        requiredRoute = "/onboarding/organization";
+    } else {
+        currentStep = OnboardingStep.COMPLETED;
+        requiredRoute = null;
+    }
+
+    const isComplete = currentStep === OnboardingStep.COMPLETED;
+
+    return {
+        currentStep,
+        accountType,
+        isComplete,
+        isLoading: false,
+        requiredRoute,
+    };
+}
+
+/**
+ * Get the step number from onboarding step stored in prefs
+ */
+export function getOnboardingStepFromPrefs(prefs: Record<string, unknown>): OnboardingStep {
+    const step = prefs.onboardingStep as string | undefined;
+
+    switch (step) {
+        case "SIGNUP_COMPLETED":
+            return OnboardingStep.SIGNUP;
+        case "EMAIL_VERIFIED":
+            return OnboardingStep.EMAIL_VERIFICATION;
+        case "ORG_SETUP_COMPLETED":
+            return OnboardingStep.ORG_SETUP;
+        case "WORKSPACE_SETUP_COMPLETED":
+            return OnboardingStep.WORKSPACE_SETUP;
+        case "COMPLETED":
+        case "WORKSPACE_SKIPPED": // User intentionally skipped workspace creation
+            return OnboardingStep.COMPLETED;
+        default:
+            return OnboardingStep.SIGNUP;
+    }
+}

--- a/src/features/organizations/api/use-add-org-member.ts
+++ b/src/features/organizations/api/use-add-org-member.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+interface AddOrgMemberData {
+    organizationId: string;
+    userId: string;
+    role: "OWNER" | "ADMIN" | "MEMBER";
+}
+
+/**
+ * Hook for adding a member to an organization
+ * ADMIN or OWNER can add members
+ */
+export const useAddOrgMember = () => {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: async ({ organizationId, userId, role }: AddOrgMemberData) => {
+            const response = await fetch(
+                `/api/organizations/${organizationId}/members`,
+                {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ userId, role }),
+                    credentials: "include",
+                }
+            );
+
+            if (!response.ok) {
+                const error = await response.json().catch(() => ({}));
+                throw new Error(error.error || "Failed to add member");
+            }
+
+            return response.json();
+        },
+        onSuccess: (_, variables) => {
+            toast.success("Member added to organization");
+            queryClient.invalidateQueries({ queryKey: ["org-members", variables.organizationId] });
+        },
+        onError: (error: Error) => {
+            toast.error(error.message || "Failed to add member");
+        },
+    });
+};

--- a/src/features/organizations/api/use-current-org-member.ts
+++ b/src/features/organizations/api/use-current-org-member.ts
@@ -1,0 +1,67 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useCurrent } from "@/features/auth/api/use-current";
+
+interface UseCurrentOrgMemberProps {
+    organizationId: string;
+}
+
+export interface CurrentOrgMember {
+    $id: string;
+    organizationId: string;
+    userId: string;
+    role: "OWNER" | "ADMIN" | "MEMBER";
+    name?: string;
+    email?: string;
+}
+
+/**
+ * Get the current user's membership and role in an organization
+ * 
+ * Returns:
+ * - role: OWNER | ADMIN | MEMBER
+ * - canEdit: true if OWNER or ADMIN
+ * - isOwner: true if OWNER
+ */
+export const useCurrentOrgMember = ({ organizationId }: UseCurrentOrgMemberProps) => {
+    const { data: user } = useCurrent();
+
+    const query = useQuery({
+        queryKey: ["current-org-member", organizationId, user?.$id],
+        queryFn: async () => {
+            if (!user?.$id) return null;
+
+            const response = await fetch(
+                `/api/organizations/${organizationId}/members`,
+                { credentials: "include" }
+            );
+
+            if (!response.ok) {
+                return null;
+            }
+
+            const data = await response.json();
+            const members = data.data?.documents || [];
+
+            // Find current user's membership
+            const membership = members.find(
+                (m: CurrentOrgMember) => m.userId === user.$id
+            );
+
+            return membership || null;
+        },
+        enabled: !!organizationId && !!user?.$id,
+    });
+
+    const role = query.data?.role || null;
+
+    return {
+        ...query,
+        role,
+        canEdit: role === "OWNER" || role === "ADMIN",
+        isOwner: role === "OWNER",
+        isAdmin: role === "ADMIN",
+        isMember: role === "MEMBER",
+    };
+};

--- a/src/features/organizations/api/use-delete-organization.ts
+++ b/src/features/organizations/api/use-delete-organization.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+interface DeleteOrganizationData {
+    organizationId: string;
+}
+
+/**
+ * Hook for soft-deleting an organization
+ * OWNER only
+ * 
+ * WHY soft-delete:
+ * - Prevents accidental data loss
+ * - Enables recovery within grace period (30 days)
+ * - Required for billing audit trail
+ */
+export const useDeleteOrganization = () => {
+    const queryClient = useQueryClient();
+    const router = useRouter();
+
+    return useMutation({
+        mutationFn: async ({ organizationId }: DeleteOrganizationData) => {
+            const response = await fetch(
+                `/api/organizations/${organizationId}`,
+                {
+                    method: "DELETE",
+                    credentials: "include",
+                }
+            );
+
+            if (!response.ok) {
+                const error = await response.json().catch(() => ({}));
+                throw new Error(error.error || "Failed to delete organization");
+            }
+
+            return response.json();
+        },
+        onSuccess: () => {
+            toast.success("Organization deleted", {
+                description: "Your organization has been scheduled for deletion.",
+            });
+            queryClient.invalidateQueries({ queryKey: ["organizations"] });
+            // Redirect to homepage after deletion
+            router.push("/");
+        },
+        onError: (error: Error) => {
+            toast.error(error.message || "Failed to delete organization");
+        },
+    });
+};

--- a/src/features/organizations/api/use-get-org-audit-logs.ts
+++ b/src/features/organizations/api/use-get-org-audit-logs.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+interface UseGetOrgAuditLogsProps {
+    organizationId: string;
+    limit?: number;
+    offset?: number;
+    actionType?: string;
+}
+
+export const useGetOrgAuditLogs = ({
+    organizationId,
+    limit = 50,
+    offset = 0,
+    actionType,
+}: UseGetOrgAuditLogsProps) => {
+    return useQuery({
+        queryKey: ["org-audit-logs", organizationId, limit, offset, actionType],
+        queryFn: async () => {
+            const params = new URLSearchParams({
+                limit: limit.toString(),
+                offset: offset.toString(),
+            });
+            if (actionType) {
+                params.set("actionType", actionType);
+            }
+
+            const response = await fetch(
+                `/api/organizations/${organizationId}/audit-logs?${params.toString()}`,
+                {
+                    credentials: "include",
+                }
+            );
+
+            if (!response.ok) {
+                throw new Error("Failed to fetch audit logs");
+            }
+
+            return response.json();
+        },
+        enabled: !!organizationId,
+    });
+};
+

--- a/src/features/organizations/api/use-get-org-members.ts
+++ b/src/features/organizations/api/use-get-org-members.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+interface UseGetOrgMembersProps {
+    organizationId: string;
+}
+
+export interface OrgMember {
+    $id: string;
+    organizationId: string;
+    userId: string;
+    role: "OWNER" | "ADMIN" | "MEMBER";
+    name?: string;
+    email?: string;
+    profileImageUrl?: string | null;
+}
+
+/**
+ * Fetch all members of an organization
+ */
+export const useGetOrgMembers = ({ organizationId }: UseGetOrgMembersProps) => {
+    return useQuery({
+        queryKey: ["org-members", organizationId],
+        queryFn: async () => {
+            const response = await fetch(
+                `/api/organizations/${organizationId}/members`,
+                { credentials: "include" }
+            );
+
+            if (!response.ok) {
+                throw new Error("Failed to fetch organization members");
+            }
+
+            const data = await response.json();
+            return data.data as { documents: OrgMember[]; total: number };
+        },
+        enabled: !!organizationId,
+    });
+};

--- a/src/features/organizations/api/use-remove-org-member.ts
+++ b/src/features/organizations/api/use-remove-org-member.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+interface RemoveOrgMemberData {
+    organizationId: string;
+    userId: string;
+}
+
+/**
+ * Hook for removing a member from an organization
+ * ADMIN or OWNER can remove members
+ * 
+ * INVARIANT: Cannot remove last OWNER
+ */
+export const useRemoveOrgMember = () => {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: async ({ organizationId, userId }: RemoveOrgMemberData) => {
+            const response = await fetch(
+                `/api/organizations/${organizationId}/members/${userId}`,
+                {
+                    method: "DELETE",
+                    credentials: "include",
+                }
+            );
+
+            if (!response.ok) {
+                const error = await response.json().catch(() => ({}));
+                throw new Error(error.error || "Failed to remove member");
+            }
+
+            return response.json();
+        },
+        onSuccess: (_, variables) => {
+            toast.success("Member removed from organization");
+            queryClient.invalidateQueries({ queryKey: ["org-members", variables.organizationId] });
+        },
+        onError: (error: Error) => {
+            toast.error(error.message || "Failed to remove member");
+        },
+    });
+};

--- a/src/features/organizations/api/use-update-org-member-role.ts
+++ b/src/features/organizations/api/use-update-org-member-role.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+interface UpdateOrgMemberRoleData {
+    organizationId: string;
+    userId: string;
+    role: "OWNER" | "ADMIN" | "MEMBER";
+}
+
+/**
+ * Hook for updating an organization member's role
+ * ADMIN or OWNER can update roles
+ * 
+ * INVARIANT: Cannot remove last OWNER
+ */
+export const useUpdateOrgMemberRole = () => {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: async ({ organizationId, userId, role }: UpdateOrgMemberRoleData) => {
+            const response = await fetch(
+                `/api/organizations/${organizationId}/members/${userId}`,
+                {
+                    method: "PATCH",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ role }),
+                    credentials: "include",
+                }
+            );
+
+            if (!response.ok) {
+                const error = await response.json().catch(() => ({}));
+                throw new Error(error.error || "Failed to update member role");
+            }
+
+            return response.json();
+        },
+        onSuccess: (_, variables) => {
+            toast.success("Member role updated");
+            queryClient.invalidateQueries({ queryKey: ["org-members", variables.organizationId] });
+        },
+        onError: (error: Error) => {
+            toast.error(error.message || "Failed to update member role");
+        },
+    });
+};

--- a/src/features/organizations/api/use-update-organization.ts
+++ b/src/features/organizations/api/use-update-organization.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+interface UpdateOrganizationData {
+    organizationId: string;
+    name?: string;
+    image?: File;
+}
+
+/**
+ * Hook for updating organization details
+ * OWNER or ADMIN can update name and image
+ */
+export const useUpdateOrganization = () => {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: async ({ organizationId, name, image }: UpdateOrganizationData) => {
+            const formData = new FormData();
+            if (name) formData.append("name", name);
+            if (image) formData.append("image", image);
+
+            const response = await fetch(`/api/organizations/${organizationId}`, {
+                method: "PATCH",
+                body: formData,
+                credentials: "include",
+            });
+
+            if (!response.ok) {
+                const error = await response.json().catch(() => ({}));
+                throw new Error(error.error || "Failed to update organization");
+            }
+
+            return response.json();
+        },
+        onSuccess: (_, variables) => {
+            toast.success("Organization updated");
+            queryClient.invalidateQueries({ queryKey: ["organization", variables.organizationId] });
+            queryClient.invalidateQueries({ queryKey: ["organizations"] });
+        },
+        onError: (error: Error) => {
+            toast.error(error.message || "Failed to update organization");
+        },
+    });
+};

--- a/src/features/organizations/audit.ts
+++ b/src/features/organizations/audit.ts
@@ -99,6 +99,12 @@ export async function logOrgAudit({
     userAgent,
 }: LogOrgAuditProps): Promise<OrgAuditLog | null> {
     try {
+        // Skip if audit log collection is not configured
+        if (!ORGANIZATION_AUDIT_LOGS_ID) {
+            console.warn("[OrgAudit] Audit log collection not configured (NEXT_PUBLIC_APPWRITE_ORGANIZATION_AUDIT_LOGS_ID)");
+            return null;
+        }
+
         const log = await databases.createDocument(
             DATABASE_ID,
             ORGANIZATION_AUDIT_LOGS_ID,

--- a/src/features/organizations/components/organization-audit-logs.tsx
+++ b/src/features/organizations/components/organization-audit-logs.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import { useState } from "react";
+import { format } from "date-fns";
+import {
+    FileText,
+    User,
+    Building2,
+    UserPlus,
+    UserMinus,
+    RefreshCcw,
+    ChevronLeft,
+    ChevronRight,
+    Filter,
+} from "lucide-react";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+
+import { useGetOrgAuditLogs } from "../api/use-get-org-audit-logs";
+import { OrgAuditAction } from "../audit";
+
+interface AuditLogEntry {
+    $id: string;
+    organizationId: string;
+    actorUserId: string;
+    actionType: string;
+    metadata: string | Record<string, unknown>;
+    timestamp: string;
+}
+
+interface OrganizationAuditLogsProps {
+    organizationId: string;
+}
+
+/**
+ * Organization Audit Logs View
+ * 
+ * Read-only display of organization audit events.
+ * Visible only to OWNER for compliance and debugging.
+ * 
+ * INVARIANTS:
+ * - No editing, deleting, or exporting (read-only)
+ * - Pagination for large datasets
+ * - Filter by action type
+ */
+export function OrganizationAuditLogs({ organizationId }: OrganizationAuditLogsProps) {
+    const [offset, setOffset] = useState(0);
+    const [actionFilter, setActionFilter] = useState<string>("all");
+    const limit = 20;
+
+    const { data, isLoading, isError, refetch, isRefetching } = useGetOrgAuditLogs({
+        organizationId,
+        limit,
+        offset,
+        actionType: actionFilter === "all" ? undefined : actionFilter,
+    });
+
+    const logs = (data?.data || []) as AuditLogEntry[];
+    const total = data?.total || 0;
+    const hasNext = offset + limit < total;
+    const hasPrev = offset > 0;
+
+    const handleNext = () => setOffset((o) => o + limit);
+    const handlePrev = () => setOffset((o) => Math.max(0, o - limit));
+
+    const getActionIcon = (action: string) => {
+        switch (action) {
+            case OrgAuditAction.ORGANIZATION_CREATED:
+            case OrgAuditAction.ORGANIZATION_DELETED:
+            case OrgAuditAction.ORGANIZATION_RESTORED:
+                return <Building2 className="h-4 w-4" />;
+            case OrgAuditAction.ACCOUNT_CONVERTED:
+                return <RefreshCcw className="h-4 w-4" />;
+            case OrgAuditAction.MEMBER_ADDED:
+                return <UserPlus className="h-4 w-4" />;
+            case OrgAuditAction.MEMBER_REMOVED:
+                return <UserMinus className="h-4 w-4" />;
+            default:
+                return <FileText className="h-4 w-4" />;
+        }
+    };
+
+    const getActionBadgeVariant = (action: string): "default" | "secondary" | "destructive" | "outline" => {
+        if (action.includes("deleted") || action.includes("removed")) return "destructive";
+        if (action.includes("created") || action.includes("added")) return "default";
+        return "secondary";
+    };
+
+    const formatAction = (action: string) => {
+        return action
+            .replace(/_/g, " ")
+            .replace(/\b\w/g, (l) => l.toUpperCase());
+    };
+
+    const formatMetadata = (metadata: string | Record<string, unknown>) => {
+        try {
+            const parsed = typeof metadata === "string" ? JSON.parse(metadata) : metadata;
+            const entries = Object.entries(parsed).slice(0, 3);
+            return entries.map(([key, value]) => `${key}: ${value}`).join(", ");
+        } catch {
+            return "-";
+        }
+    };
+
+    if (isError) {
+        return (
+            <Card>
+                <CardContent className="py-8">
+                    <div className="text-center text-muted-foreground">
+                        <FileText className="h-8 w-8 mx-auto mb-2 opacity-50" />
+                        <p>Failed to load audit logs</p>
+                        <Button variant="outline" size="sm" onClick={() => refetch()} className="mt-2">
+                            Try Again
+                        </Button>
+                    </div>
+                </CardContent>
+            </Card>
+        );
+    }
+
+    return (
+        <Card>
+            <CardHeader>
+                <div className="flex items-center justify-between">
+                    <div>
+                        <CardTitle className="flex items-center gap-2">
+                            <FileText className="h-5 w-5" />
+                            Audit Logs
+                        </CardTitle>
+                        <CardDescription>
+                            Read-only view of organization activity for compliance
+                        </CardDescription>
+                    </div>
+                    <div className="flex items-center gap-2">
+                        <Select value={actionFilter} onValueChange={(v) => { setActionFilter(v); setOffset(0); }}>
+                            <SelectTrigger className="w-[180px] h-8 text-xs">
+                                <Filter className="h-3 w-3 mr-1" />
+                                <SelectValue placeholder="Filter by action" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="all">All Actions</SelectItem>
+                                <SelectItem value={OrgAuditAction.ORGANIZATION_CREATED}>Created</SelectItem>
+                                <SelectItem value={OrgAuditAction.ACCOUNT_CONVERTED}>Converted</SelectItem>
+                                <SelectItem value={OrgAuditAction.MEMBER_ADDED}>Member Added</SelectItem>
+                                <SelectItem value={OrgAuditAction.MEMBER_REMOVED}>Member Removed</SelectItem>
+                                <SelectItem value={OrgAuditAction.MEMBER_ROLE_CHANGED}>Role Changed</SelectItem>
+                                <SelectItem value={OrgAuditAction.ORGANIZATION_DELETED}>Deleted</SelectItem>
+                            </SelectContent>
+                        </Select>
+                        <Button variant="ghost" size="sm" onClick={() => refetch()} disabled={isRefetching}>
+                            <RefreshCcw className={`h-4 w-4 ${isRefetching ? "animate-spin" : ""}`} />
+                        </Button>
+                    </div>
+                </div>
+            </CardHeader>
+            <CardContent>
+                {isLoading ? (
+                    <div className="space-y-3">
+                        {[...Array(5)].map((_, i) => (
+                            <div key={i} className="flex items-center gap-3 p-3 border rounded-lg">
+                                <Skeleton className="h-8 w-8 rounded-full" />
+                                <div className="flex-1 space-y-2">
+                                    <Skeleton className="h-4 w-1/3" />
+                                    <Skeleton className="h-3 w-2/3" />
+                                </div>
+                                <Skeleton className="h-4 w-20" />
+                            </div>
+                        ))}
+                    </div>
+                ) : logs.length === 0 ? (
+                    <div className="text-center py-8 text-muted-foreground">
+                        <FileText className="h-8 w-8 mx-auto mb-2 opacity-50" />
+                        <p>No audit logs found</p>
+                    </div>
+                ) : (
+                    <>
+                        <div className="space-y-2">
+                            {logs.map((log) => (
+                                <div
+                                    key={log.$id}
+                                    className="flex items-start gap-3 p-3 border rounded-lg hover:bg-muted/50 transition-colors"
+                                >
+                                    <div className="flex items-center justify-center h-8 w-8 rounded-full bg-muted">
+                                        {getActionIcon(log.actionType)}
+                                    </div>
+                                    <div className="flex-1 min-w-0">
+                                        <div className="flex items-center gap-2 mb-1">
+                                            <Badge variant={getActionBadgeVariant(log.actionType)} className="text-xs">
+                                                {formatAction(log.actionType)}
+                                            </Badge>
+                                            <span className="text-xs text-muted-foreground flex items-center gap-1">
+                                                <User className="h-3 w-3" />
+                                                {log.actorUserId.slice(0, 8)}...
+                                            </span>
+                                        </div>
+                                        <p className="text-xs text-muted-foreground truncate">
+                                            {formatMetadata(log.metadata)}
+                                        </p>
+                                    </div>
+                                    <div className="text-right">
+                                        <p className="text-xs text-muted-foreground">
+                                            {format(new Date(log.timestamp), "MMM d, yyyy")}
+                                        </p>
+                                        <p className="text-xs text-muted-foreground">
+                                            {format(new Date(log.timestamp), "h:mm a")}
+                                        </p>
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+
+                        {/* Pagination */}
+                        <div className="flex items-center justify-between mt-4 pt-4 border-t">
+                            <p className="text-xs text-muted-foreground">
+                                Showing {offset + 1}-{Math.min(offset + limit, total)} of {total}
+                            </p>
+                            <div className="flex items-center gap-1">
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={handlePrev}
+                                    disabled={!hasPrev}
+                                >
+                                    <ChevronLeft className="h-4 w-4" />
+                                </Button>
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={handleNext}
+                                    disabled={!hasNext}
+                                >
+                                    <ChevronRight className="h-4 w-4" />
+                                </Button>
+                            </div>
+                        </div>
+                    </>
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/src/hooks/use-app-refresh.ts
+++ b/src/hooks/use-app-refresh.ts
@@ -1,47 +1,103 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useState, useRef } from "react";
 import { useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 
 /**
- * Hook for refreshing app data without full page reload
+ * PRODUCTION POLISH: Safe Global Refresh with Throttling
  * 
- * Refreshes:
- * - Active workspace
- * - Organizations
- * - Current user
- * - Permissions (via cache invalidation)
+ * WHY REFRESH DOES NOT RELOAD THE PAGE:
+ * - Preserves user context (filters, scroll position, open modals)
+ * - Only invalidates React Query cache to trigger refetch
+ * - Faster than full page reload
+ * - Better UX for slow connections
  * 
- * Rules:
- * - Refresh is blocked while already refreshing
- * - Does NOT reset filters, tabs, or scroll position
- * - Does NOT reload the page
+ * THROTTLING STRATEGY:
+ * - Prevents multiple refreshes within 2-second window
+ * - Batches core queries first (auth, workspace, permissions)
+ * - Defers heavy queries (billing, analytics) by 500ms
+ * - This reduces perceived lag on slow networks
+ * 
+ * ACCESS LOSS DETECTION:
+ * - If 401/403 detected after refresh, redirect gracefully
+ * - Shows friendly "Your access has changed" message
+ * - Prevents raw error screens for expected permission changes
  */
+
+const THROTTLE_MS = 2000; // Minimum time between refreshes
+const DEFER_HEAVY_QUERIES_MS = 500; // Delay for billing/analytics queries
+
 export const useAppRefresh = () => {
     const queryClient = useQueryClient();
+    const router = useRouter();
     const [isRefreshing, setIsRefreshing] = useState(false);
+    const lastRefreshRef = useRef<number>(0);
 
     const refresh = useCallback(async () => {
+        // Guard: Prevent refresh while already refreshing
         if (isRefreshing) return;
 
+        // Guard: Throttle - prevent rapid consecutive refreshes
+        const now = Date.now();
+        if (now - lastRefreshRef.current < THROTTLE_MS) {
+            console.log("[Refresh] Throttled - too soon since last refresh");
+            return;
+        }
+
+        lastRefreshRef.current = now;
         setIsRefreshing(true);
 
         try {
-            // Invalidate all relevant queries to trigger refetch
+            // BATCH 1: Core queries (immediate)
+            // These are essential for app functionality
             await Promise.all([
                 queryClient.invalidateQueries({ queryKey: ["current"] }),
                 queryClient.invalidateQueries({ queryKey: ["workspaces"] }),
                 queryClient.invalidateQueries({ queryKey: ["organizations"] }),
                 queryClient.invalidateQueries({ queryKey: ["members"] }),
-                // Add more query keys as needed
             ]);
+
+            // BATCH 2: Heavy queries (deferred)
+            // Billing and analytics can wait slightly
+            setTimeout(() => {
+                queryClient.invalidateQueries({ queryKey: ["usage"] });
+                queryClient.invalidateQueries({ queryKey: ["billing"] });
+                queryClient.invalidateQueries({ queryKey: ["analytics"] });
+                queryClient.invalidateQueries({ queryKey: ["audit-logs"] });
+            }, DEFER_HEAVY_QUERIES_MS);
+
+        } catch (error) {
+            // ACCESS LOSS DETECTION
+            // If refresh fails with auth error, handle gracefully
+            const err = error as { status?: number; code?: number };
+
+            if (err.status === 401 || err.code === 401) {
+                toast.info("Your session has expired", {
+                    description: "Please sign in again to continue.",
+                });
+                router.push("/sign-in");
+                return;
+            }
+
+            if (err.status === 403 || err.code === 403) {
+                toast.info("Your access has changed", {
+                    description: "You may no longer have access to this resource.",
+                });
+                router.push("/");
+                return;
+            }
+
+            // For other errors, log but don't crash
+            console.error("[Refresh] Error during refresh:", error);
         } finally {
-            // Small delay to ensure UI shows refresh state
+            // Ensure UI shows refresh state briefly
             setTimeout(() => {
                 setIsRefreshing(false);
             }, 500);
         }
-    }, [queryClient, isRefreshing]);
+    }, [queryClient, router, isRefreshing]);
 
     return {
         refresh,
@@ -51,6 +107,9 @@ export const useAppRefresh = () => {
 
 /**
  * Hook for screen-level refresh (specific query keys)
+ * 
+ * Use this when you only need to refresh specific data,
+ * not the entire app state.
  */
 export const useScreenRefresh = (queryKeys: string[]) => {
     const queryClient = useQueryClient();


### PR DESCRIPTION
fix(org): allow full org management without requiring a workspace

- Corrected org vs workspace hierarchy logic (org = control plane)
- Enabled org owners/admins to manage organization with zero workspaces
- Unblocked org-level features: settings, members, billing, audit logs
- Fixed sidebar rendering to separate org-scoped vs workspace-scoped items
- Removed incorrect “Available after creating a workspace” restriction for org features
- Treated zero-workspace org state as valid and first-class
- Kept workspace-dependent features gated behind active workspace
- Preserved existing behavior for personal accounts

Result:
- Org admins can invite members, manage org, and create workspaces independently
- No errors or blocked UI after skipping workspace creation
- UX now aligns with enterprise PMT mental model
